### PR TITLE
fast version of locateAll() using OpenCV

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -36,6 +36,7 @@ import time
 from pyscreeze import *
 from pymsgbox import *
 from pytweening import *
+from screenshotUtil import *
 
 import pyscreeze # used so we can change the RAISE_IF_NOT_FOUND and GRAYSCALE_DEFAULT variables
 

--- a/pyautogui/screenshotUtil.py
+++ b/pyautogui/screenshotUtil.py
@@ -11,8 +11,6 @@ import datetime
 import os
 import subprocess
 import sys
-from PIL import Image
-from PIL import ImageOps
 import cv2
 import numpy as np
 
@@ -30,24 +28,24 @@ except:
 
 def locateAll(needleImage, haystackImage, grayscale=False, limit=None, confidence=0.999):
     """generate location(s) of needle image in haystack, confidence threshold
-
-    `grayscale` is ignored, for backwards compatibilty only
     """
     # code adapted from https://stackoverflow.com/questions/7670112/finding-a-subimage-inside-a-numpy-image/9253805#9253805
     # "OpenCV uses BGR channel order by default, so be careful, e.g. when you compare an image you loaded with cv2.imread to an image you converted from PIL to numpy. You can always use cv2.cvtColor to convert between formats."
+    if grayscale:
+        load_fmt = cv2.CV_LOAD_IMAGE_GRAYSCALE
+    else:
+        load_fmt = cv2.CV_LOAD_IMAGE_COLOR
+
+    # load images from filenames:
     if isinstance(needleImage, str):
-        # 'image' is a filename, load the Image object
-        needleImage = cv2.imread(needleImage)
+        needleImage = cv2.imread(needleImage, load_fmt)
+        needleHeight, needleWidth = needleImage.shape[:2]
     else:
-        # TO-DO: convert to cv; see caveat about conversion
-        pass  # will probably fail below
+        raise NotImplementedError  # TO-DO: convert to cv; see caveat about BGR conversion
     if isinstance(haystackImage, str):
-        # 'image' is a filename, load the Image object
-        haystackImage = cv2.imread(haystackImage)
+        haystackImage = cv2.imread(haystackImage, load_fmt)
     else:
-        # TO-DO: convert to cv; see caveat about conversion
-        pass  # will probably fail below
-    needleHeight, needleWidth = needleImage.shape[:2]
+        raise NotImplementedError  # TO-DO: convert to cv; see caveat about BGR conversion
 
     result = cv2.matchTemplate(haystackImage, needleImage, cv2.TM_CCOEFF_NORMED)
     match_indices = np.arange(result.size)[(result > confidence).flatten()]


### PR DESCRIPTION
I'm putting this out there as a basis for discussion. If its acceptable to require OpenCV and numpy as dependencies (in return for faster performance), then I'll test this more and smooth out the remaining wrinkles. But maybe you don't want the extra dependencies.

Upsides:
  - faster: for me, finding a small image in a 2880 x 1800 pix screenshot takes ~0.95s vs ~4.5s previously
      (with grayscale and downsampling by 4 its faster still: ~0.10s)
  - confidence-based thresholding is possible: I have not played with this much, looks interesting
  - less code required

Downside: 
  - requires OpenCV (and numpy), not sure if OpenCV is working well with python 3 on all platforms yet

Limitations:
- not thoroughly tested yet but looks very promising
- takes file names only (not PIL images, which would need to be converted)
- only tested on Mac 10.9, 64-bit python 2.7.8, OpenCV 2.4.8

I needed to explicitly import screenshotUtil * to get the new code to be used
  (I'm baffled how locate() gets into the pyautogui namespace without doing this!)

credits: https://stackoverflow.com/questions/7670112/finding-a-subimage-inside-a-numpy-image/9253805#9253805