### PR TITLE
Fixed dragging bug on OSX

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -13,3 +13,4 @@ https://github.com/danielboone
 https://github.com/hey-sancho
 https://github.com/lb1a
 Jeremy R. Gray https://github.com/jeremygray
+Ashok Fernandez https://github.com/ashokfernandez/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.9.25  2015/01/27 -- Fixed dragTo() bug on OS X
 v0.9.24, 2015/01/07 -- Added -x silent option to os x screencapture command.
 v0.9.23, 2015/01/06 -- Now allowing lists in addition to tuples for XY coordinate arguments.
 v0.9.22, 2015/01/06 -- Added "pause" keyword argument to functions to override PAUSE setting for specific calls.

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -648,7 +648,7 @@ def dragTo(x=None, y=None, duration=0.0, tween=linear, button='left', pause=None
     if type(x) in (tuple, list):
         x, y = x[0], x[1]
     mouseDown(button=button, _pause=False)
-    _mouseMoveDragTo('drag', x, y, duration, tween)
+    _mouseMoveDragTo('drag', x, y, duration, tween, button)
     mouseUp(button=button, _pause=False)
 
     if pause is not None and _pause:


### PR DESCRIPTION
When dragTo() was called on OS X the button parameter wasn’t passed
through, which cause an assertion to fail within the OS X module.