### PR TITLE
Redefine pause argument in press function

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -903,10 +903,10 @@ def press(keys, presses=1, pause=None, _pause=True):
             platformModule._keyDown(k)
             platformModule._keyUp(k)
 
-    if pause is not None and _pause:
-        time.sleep(pause)
-    elif _pause and PAUSE != 0:
-        time.sleep(PAUSE)
+        if pause is not None and _pause:
+            time.sleep(pause)
+        elif _pause and PAUSE != 0:
+            time.sleep(PAUSE)
 
 def typewrite(message, interval=0.0, pause=None, _pause=True):
     """Performs a keyboard key press down, followed by a release, for each of


### PR DESCRIPTION
The "pause" argument in press function runs just in the end of all presses, I mean, if you use " press('enter', presses=3, pause=1) " the function simulate "enter" three times and after that pause during 1sec. I understand that the best should be make 1sec pause after each 'enter'.