### PR TITLE
Avoid GetLastError result raised from others.

### DIFF
--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -474,6 +474,7 @@ def _sendMouseEvent(ev, x, y, dwData=0):
     width, height = _size()
     convertedX = 65536 * x // width + 1
     convertedY = 65536 * y // height + 1
+    ctypes.windll.kernel32.SetLastError(0)
     ctypes.windll.user32.mouse_event(ev, ctypes.c_long(convertedX), ctypes.c_long(convertedY), dwData, 0)
 
     if ctypes.windll.kernel32.GetLastError() != 0:


### PR DESCRIPTION
It could raise the error from other methods. To specify the error from the method, I recommend to reset the LastError on Windows.
In addition, PIL.Image.Image.save() makes Windows Error 183 but automatically overwrite the file when the file has already existed.  The error from this method isn't deleted after executed.