### PR TITLE
Bug Fix: Issue #12

### DIFF
--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -295,7 +295,7 @@ def _position():
 
 
 def _size():
-    return Quartz.CGDisplayPixelsWide(0), Quartz.CGDisplayPixelsHigh(0)
+    return Quartz.CGDisplayPixelsWide(Quartz.CGMainDisplayID()), Quartz.CGDisplayPixelsHigh(Quartz.CGMainDisplayID())
 
 
 


### PR DESCRIPTION
#### Issue Description: 
Calls to CGDisplayPixelsWidth and CGDisplayPixelsHeight stall when passed an integer argument of 0 for OS X 10.9.5 - 10.10.3 (Retina). 

#### Details:
This issue is reproducible in objective Objective-C, this is not an issue with pyobjc itself. The Objective-C documentation for the functions state that the required arguments be of type [CGMainDisplayID (unsigned int)](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/Quartz_Services_Ref/index.html#//apple_ref/c/func/CGMainDisplayID), and recommends that the display ID be retrieved using the CGMainDisplayID function. So this issue is likely due to a change in a stricter implementation of the aforementioned functions, such 0 is no longer allowed as a DisplayID. Below is sample code in Objective-C which reproduces the issue, and will stall when CGDDisplayPixelsWide is called with argument 0.

```objective-c
#import <Foundation/Foundation.h>

int main(int argc, const char * argv[]) {
    CGDisplayPixelsWide(0);
    return 0;
}
```

#### Solution: 
The solution to this issue is to use Quarts.CGMainDisplayID() to retrieve the main display ID, instead of 0. As this is method for retrieving the display ID it should prove to be a robust solution in the long term.