### PR TITLE
lost a single quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Example Usage
 
 Keyboard and Mouse Control
 --------------------------
-
+```python
     >>> import pyautogui
     >>> screenWidth, screenHeight = pyautogui.size()
     >>> currentMouseX, currentMouseY = pyautogui.position()
@@ -50,10 +50,11 @@ Keyboard and Mouse Control
     >>> pyautogui.typewrite(['left', 'left', 'left', 'left', 'left', 'left'])
     >>> pyautogui.keyUp('shift')
     >>> pyautogui.hotkey('ctrl', 'c')
+```
 
 Display Message Boxes
 ---------------------
-
+```python
     >>> import pyautogui
     >>> pyautogui.alert('This is an alert box.')
     'OK'
@@ -65,19 +66,19 @@ Display Message Boxes
     'Al'
     >>> pyautogui.password('Enter password (text will be hidden)')
     'swordfish'
-
+```
 Screenshot Functions
 --------------------
 
 (PyAutoGUI uses Pillow for image-related features.)
-
+```python
     >>> import pyautogui
     >>> im1 = pyautogui.screenshot()
     >>> im1.save('my_screenshot.png')
     >>> im2 = pyautogui.screenshot('my_screenshot2.png')
-
+```
 You can also locate where an image is on the screen:
-
+```python
     >>> import pyautogui
     >>> button7location = pyautogui.locateOnScreen('button.png') # returns (left, top, width, height) of matching region
     >>> button7location
@@ -86,11 +87,12 @@ You can also locate where an image is on the screen:
     >>> buttonx, buttony
     (1441, 582)
     >>> pyautogui.click(buttonx, buttony)  # clicks the center of where the button was found
-
+```
 The locateCenterOnScreen() function returns the center of this match region:
-
+```python
     >>> import pyautogui
     >>> buttonx, buttony = pyautogui.locateCenterOnScreen('button.png') # returns (x, y) of matching region
     >>> buttonx, buttony
     (1441, 582)
     >>> pyautogui.click(buttonx, buttony)  # clicks the center of where the button was found
+```

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -85,8 +85,8 @@ The full list of key names is in `pyautogui.KEYBOARD_KEYS`.
 
 Keyboard hotkeys like Ctrl-S or Ctrl-Shift-1 can be done by passing a list of key names to `hotkey()`:
 
-    >>> pyautogui.hotkey(['ctrl', 'c'])  # ctrl-c to copy
-    >>> pyautogui.hotkey(['ctrl', 'v'])  # ctrl-v to paste
+    >>> pyautogui.hotkey('ctrl', 'c')  # ctrl-c to copy
+    >>> pyautogui.hotkey('ctrl', 'v')  # ctrl-v to paste
 
 Individual button down and up events can be called separately:
 

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -67,8 +67,8 @@ Positive scrolling will scroll up, negative scrolling will scroll down:
 
 Individual button down and up events can be called separately:
 
-    >>> mouseDown(x=moveToX, y=moveToY, button='left')
-    >>> mouseUp(x=moveToX, y=moveToY, button='left')
+    >>> pyautogui.mouseDown(x=moveToX, y=moveToY, button='left')
+    >>> pyautogui.mouseUp(x=moveToX, y=moveToY, button='left')
 
 Keyboard Functions
 ------------------
@@ -79,7 +79,7 @@ Key presses go to wherever the keyboard cursor is at function-calling time.
 
 A list of key names can be passed too:
 
-    >>> pyautogui.typewrite(['a', 'b', 'c', left', 'backspace', 'enter', 'f1'], interval=secs_between_keys)
+    >>> pyautogui.typewrite(['a', 'b', 'c', 'left', 'backspace', 'enter', 'f1'], interval=secs_between_keys)
 
 The full list of key names is in `pyautogui.KEYBOARD_KEYS`.
 

--- a/docs/keyboard.rst
+++ b/docs/keyboard.rst
@@ -45,7 +45,7 @@ To press multiple keys similar to what ``typewrite()`` does, pass a list of stri
 
 .. code:: python
 
-    >>> pyautogui.keyDown(['left', 'left', 'left'])
+    >>> pyautogui.press(['left', 'left', 'left'])
 
 
 The hotkey() Function

--- a/docs/mouse.rst
+++ b/docs/mouse.rst
@@ -109,8 +109,8 @@ If you want to move the mouse cursor over a few pixels *relative* to its current
 
     >>> pyautogui.moveTo(100, 200)   # moves mouse to X of 100, Y of 200.
     >>> pyautogui.moveRel(0, 50)     # move the mouse down 50 pixels.
-    >>> pyautogui.moveRel(30, 0)     # move the mouse left 30 pixels.
-    >>> pyautogui.moveRel(30, None)  # move the mouse left 30 pixels.
+    >>> pyautogui.moveRel(-30, 0)     # move the mouse left 30 pixels.
+    >>> pyautogui.moveRel(-30, None)  # move the mouse left 30 pixels.
 
 Mouse Drags
 ===========

--- a/docs/msgbox.rst
+++ b/docs/msgbox.rst
@@ -23,14 +23,14 @@ Displays a message box with OK and Cancel buttons. Number and text of buttons ca
 The prompt() Function
 =====================
 
-    >>> prompt(text='', title='' , defaultValue='')
+    >>> prompt(text='', title='' , default='')
 
 Displays a message box with text input, and OK & Cancel buttons. Returns the text entered, or None if Cancel was clicked.
 
 The password() Function
 =======================
 
-    >>> password(text='', title='', defaultValue='', mask='*')
+    >>> password(text='', title='', default='', mask='*')
 
 Displays a message box with text input, and OK & Cancel buttons. Typed characters appear as *. Returns the text entered, or None if Cancel was clicked.
 


### PR DESCRIPTION
```python
pyautogui.typewrite(['a', 'b', 'c', 'left', 'backspace', 'enter', 'f1'], interval=secs_between_keys)
```