### PR TITLE
Support for french layout keyboard

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -867,14 +867,17 @@ def setKeyboardLayout(target = 'qwerty'):
     Returns:
       None
     """
-    target = target.lower()
-    if (target == 'qwerty'):
-        platformModule._setEnglishLayout()
-    elif(target == 'azerty'):
-        platformModule._setFrenchLayout()
+    if (sys.platform == 'darwin' or sys.platform == 'win32'):
+        target = target.lower()
+        if (target == 'qwerty'):
+            platformModule._setEnglishLayout()
+        elif(target == 'azerty'):
+            platformModule._setFrenchLayout()
+        else:
+            print('Does not recognize <'+target+'> layout. Setting <QWERTY> instead.')
+            platformModule._setEnglishLayout()
     else:
-        print('Does not recognize <'+target+'> layout. Setting <QWERTY> instead.')
-        platformModule._setEnglishLayout()
+        print('Your operating system does not need to change keyboard layout')
 
 def keyDown(key, pause=None, _pause=True):
     """Performs a keyboard key press without the release. This will put that

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -856,6 +856,25 @@ def isValidKey(key):
     """
     return platformModule.keyboardMapping.get(key, None) != None
 
+def setKeyboardLayout(target = 'qwerty'):
+    """Change keyboard layout, needed for OSX and Windows operating system.
+
+    NOTE: Support for QWERTY and AZERTY only
+
+    Args:
+      target (str): Keyboard layout target, set qwerty for US keyboard or azerty for FR keyboard.
+
+    Returns:
+      None
+    """
+    target = target.lower()
+    if (target == 'qwerty'):
+        platformModule._setEnglishLayout()
+    elif(target == 'azerty'):
+        platformModule._setFrenchLayout()
+    else:
+        print('Does not recognize <'+target+'> layout. Setting <QWERTY> instead.')
+        platformModule._setEnglishLayout()
 
 def keyDown(key, pause=None, _pause=True):
     """Performs a keyboard key press without the release. This will put that

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -214,6 +214,7 @@ special_key_translate_table = {
 }
 
 keysShiftFR = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '_', '*', '?', '.', '/', '+', '#', '£', '°', '>']
+keysAltFR = ['{', '}', '[', ']']
 enableFrenchLayout = False
 
 def _setEnglishLayout():
@@ -228,7 +229,6 @@ def _setEnglishLayout():
           None
     """
     global enableFrenchLayout
-    global keyboardMapping
     keyboardMapping.update({
         'a': 0x00, # kVK_ANSI_A
         's': 0x01, # kVK_ANSI_S
@@ -381,7 +381,6 @@ def _setFrenchLayout():
           None
     """
     global enableFrenchLayout
-    global keyboardMapping
     keyboardMapping.update({
         'a': 0x0c, # kVK_ANSI_A |
         's': 0x01, # kVK_ANSI_S |
@@ -419,10 +418,10 @@ def _setFrenchLayout():
         ')': 0x1b, # kVK_ANSI_9 |
         '7': 0x1a, # kVK_ANSI_7
         #'&': 0x12, # kVK_ANSI_7
-        '-': 0x1b, # kVK_ANSI_Minus |
-        '_': 0x1b, # kVK_ANSI_Minus |
+        '-': 0x18, # kVK_ANSI_Minus |
+        '_': 0x18, # kVK_ANSI_Minus |
         '8': 0x1c, # kVK_ANSI_8
-        '*': 0x1c, # kVK_ANSI_8
+        '*': 0x1e, # kVK_ANSI_8
         '0': 0x1d, # kVK_ANSI_0
         #')': 0x1d, # kVK_ANSI_0
         ']': 0x1b, # kVK_ANSI_RightBracket |
@@ -435,8 +434,8 @@ def _setFrenchLayout():
         'p': 0x23, # kVK_ANSI_P |
         'l': 0x25, # kVK_ANSI_L |
         'j': 0x26, # kVK_ANSI_J |
-        "'": 0x27, # kVK_ANSI_Quote
-        '"': 0x27, # kVK_ANSI_Quote
+        "'": 0x15, # kVK_ANSI_Quote
+        '"': 0x14, # kVK_ANSI_Quote
         'k': 0x28, # kVK_ANSI_K |
         ';': 0x2b, # kVK_ANSI_Semicolon |
         ':': 0x2f, # kVK_ANSI_Semicolon |
@@ -547,6 +546,14 @@ def _normalKeyEvent(key, upDown):
     try:
 
         if (enableFrenchLayout):
+            
+            if key in keysAltFR:
+                event = Quartz.CGEventCreateKeyboardEvent(None,
+                        keyboardMapping['alt'], upDown == 'down')
+                Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
+                # Tiny sleep to let OS X catch up on us pressing alt
+                time.sleep(0.01)
+            
             if key in keysShiftFR or (key >= 'A' and key <= 'Z'):
                 key_code = keyboardMapping[key.lower()]
 
@@ -558,17 +565,20 @@ def _normalKeyEvent(key, upDown):
             else:
                 key_code = keyboardMapping[key]
 
-        if enableFrenchLayout == False and pyautogui.isShiftCharacter(key):
-            key_code = keyboardMapping[key.lower()]
-
-            event = Quartz.CGEventCreateKeyboardEvent(None,
-                        keyboardMapping['shift'], upDown == 'down')
-            Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
-            # Tiny sleep to let OS X catch up on us pressing shift
-            time.sleep(0.01)
-
         else:
-            key_code = keyboardMapping[key]
+            if pyautogui.isShiftCharacter(key):
+                key_code = keyboardMapping[key.lower()]
+            
+                event = Quartz.CGEventCreateKeyboardEvent(None,
+                        keyboardMapping['shift'], upDown == 'down')
+                Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
+                # Tiny sleep to let OS X catch up on us pressing shift
+                time.sleep(0.01)
+        
+            else:
+                key_code = keyboardMapping[key]
+
+
 
         event = Quartz.CGEventCreateKeyboardEvent(None, key_code, upDown == 'down')
         Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -228,6 +228,7 @@ def _setEnglishLayout():
           None
     """
     global enableFrenchLayout
+    global keyboardMapping
     keyboardMapping.update({
         'a': 0x00, # kVK_ANSI_A
         's': 0x01, # kVK_ANSI_S
@@ -380,6 +381,7 @@ def _setFrenchLayout():
           None
     """
     global enableFrenchLayout
+    global keyboardMapping
     keyboardMapping.update({
         'a': 0x0c, # kVK_ANSI_A |
         's': 0x01, # kVK_ANSI_S |

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -213,6 +213,9 @@ special_key_translate_table = {
     'KEYTYPE_ILLUMINATION_TOGGLE': 23
 }
 
+keysShiftFR = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '_', '*', '?', '.', '/', '+', '#', '£', '°', '>']
+enableFrenchLayout = False
+
 def _setEnglishLayout():
     """
         Use win32api in order to load and set english layout keyboard for current thread only.
@@ -224,7 +227,7 @@ def _setEnglishLayout():
         Returns:
           None
     """
-
+    global enableFrenchLayout
     keyboardMapping.update({
         'a': 0x00, # kVK_ANSI_A
         's': 0x01, # kVK_ANSI_S
@@ -362,6 +365,8 @@ def _setEnglishLayout():
         'eisu': 0x66, # kVK_JIS_Eisu
         'kana': 0x68, # kVK_JIS_Kana
     })
+    
+    enableFrenchLayout = False
 
 def _setFrenchLayout():
     """
@@ -374,7 +379,7 @@ def _setFrenchLayout():
         Returns:
           None
     """
-    
+    global enableFrenchLayout
     keyboardMapping.update({
         'a': 0x0c, # kVK_ANSI_A |
         's': 0x01, # kVK_ANSI_S |
@@ -513,6 +518,7 @@ def _setFrenchLayout():
         'eisu': 0x66, # kVK_JIS_Eisu
         'kana': 0x68, # kVK_JIS_Kana
     })
+    enableFrenchLayout = True
 
 def _keyDown(key):
     if key not in keyboardMapping or keyboardMapping[key] is None:
@@ -537,7 +543,20 @@ def _normalKeyEvent(key, upDown):
     assert upDown in ('up', 'down'), "upDown argument must be 'up' or 'down'"
 
     try:
-        if pyautogui.isShiftCharacter(key):
+
+        if (enableFrenchLayout):
+            if key in keysShiftFR:
+                key_code = keyboardMapping[key.lower()]
+
+                event = Quartz.CGEventCreateKeyboardEvent(None,
+                            keyboardMapping['shift'], upDown == 'down')
+                Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
+                # Tiny sleep to let OS X catch up on us pressing shift
+                time.sleep(0.01)
+            else:
+                key_code = keyboardMapping[key]
+
+        if enableFrenchLayout == False and pyautogui.isShiftCharacter(key):
             key_code = keyboardMapping[key.lower()]
 
             event = Quartz.CGEventCreateKeyboardEvent(None,
@@ -581,14 +600,6 @@ def _specialKeyEvent(key, upDown):
         )
 
     Quartz.CGEventPost(0, ev.CGEvent())
-
-
-
-
-
-
-
-
 
 def _position():
     loc = AppKit.NSEvent.mouseLocation()

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -545,7 +545,7 @@ def _normalKeyEvent(key, upDown):
     try:
 
         if (enableFrenchLayout):
-            if key in keysShiftFR:
+            if key in keysShiftFR or (key >= 'A' and key <= 'Z'):
                 key_code = keyboardMapping[key.lower()]
 
                 event = Quartz.CGEventCreateKeyboardEvent(None,

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -213,6 +213,307 @@ special_key_translate_table = {
     'KEYTYPE_ILLUMINATION_TOGGLE': 23
 }
 
+def _setEnglishLayout():
+    """
+        Use win32api in order to load and set english layout keyboard for current thread only.
+        Reload keymapping after loading new key layout. (QWERTY)
+
+        Args:
+          No argument are needed.
+
+        Returns:
+          None
+    """
+
+    keyboardMapping.update({
+        'a': 0x00, # kVK_ANSI_A
+        's': 0x01, # kVK_ANSI_S
+        'd': 0x02, # kVK_ANSI_D
+        'f': 0x03, # kVK_ANSI_F
+        'h': 0x04, # kVK_ANSI_H
+        'g': 0x05, # kVK_ANSI_G
+        'z': 0x06, # kVK_ANSI_Z
+        'x': 0x07, # kVK_ANSI_X
+        'c': 0x08, # kVK_ANSI_C
+        'v': 0x09, # kVK_ANSI_V
+        'b': 0x0b, # kVK_ANSI_B
+        'q': 0x0c, # kVK_ANSI_Q
+        'w': 0x0d, # kVK_ANSI_W
+        'e': 0x0e, # kVK_ANSI_E
+        'r': 0x0f, # kVK_ANSI_R
+        'y': 0x10, # kVK_ANSI_Y
+        't': 0x11, # kVK_ANSI_T
+        '1': 0x12, # kVK_ANSI_1
+        '!': 0x12, # kVK_ANSI_1
+        '2': 0x13, # kVK_ANSI_2
+        '@': 0x13, # kVK_ANSI_2
+        '3': 0x14, # kVK_ANSI_3
+        '#': 0x14, # kVK_ANSI_3
+        '4': 0x15, # kVK_ANSI_4
+        '$': 0x15, # kVK_ANSI_4
+        '6': 0x16, # kVK_ANSI_6
+        '^': 0x16, # kVK_ANSI_6
+        '5': 0x17, # kVK_ANSI_5
+        '%': 0x17, # kVK_ANSI_5
+        '=': 0x18, # kVK_ANSI_Equal
+        '+': 0x18, # kVK_ANSI_Equal
+        '9': 0x19, # kVK_ANSI_9
+        '(': 0x19, # kVK_ANSI_9
+        '7': 0x1a, # kVK_ANSI_7
+        '&': 0x1a, # kVK_ANSI_7
+        '-': 0x1b, # kVK_ANSI_Minus
+        '_': 0x1b, # kVK_ANSI_Minus
+        '8': 0x1c, # kVK_ANSI_8
+        '*': 0x1c, # kVK_ANSI_8
+        '0': 0x1d, # kVK_ANSI_0
+        ')': 0x1d, # kVK_ANSI_0
+        ']': 0x1e, # kVK_ANSI_RightBracket
+        '}': 0x1e, # kVK_ANSI_RightBracket
+        'o': 0x1f, # kVK_ANSI_O
+        'u': 0x20, # kVK_ANSI_U
+        '[': 0x21, # kVK_ANSI_LeftBracket
+        '{': 0x21, # kVK_ANSI_LeftBracket
+        'i': 0x22, # kVK_ANSI_I
+        'p': 0x23, # kVK_ANSI_P
+        'l': 0x25, # kVK_ANSI_L
+        'j': 0x26, # kVK_ANSI_J
+        "'": 0x27, # kVK_ANSI_Quote
+        '"': 0x27, # kVK_ANSI_Quote
+        'k': 0x28, # kVK_ANSI_K
+        ';': 0x29, # kVK_ANSI_Semicolon
+        ':': 0x29, # kVK_ANSI_Semicolon
+        '\\': 0x2a, # kVK_ANSI_Backslash
+        '|': 0x2a, # kVK_ANSI_Backslash
+        ',': 0x2b, # kVK_ANSI_Comma
+        '<': 0x2b, # kVK_ANSI_Comma
+        '/': 0x2c, # kVK_ANSI_Slash
+        '?': 0x2c, # kVK_ANSI_Slash
+        'n': 0x2d, # kVK_ANSI_N
+        'm': 0x2e, # kVK_ANSI_M
+        '.': 0x2f, # kVK_ANSI_Period
+        '>': 0x2f, # kVK_ANSI_Period
+        '`': 0x32, # kVK_ANSI_Grave
+        '~': 0x32, # kVK_ANSI_Grave
+        ' ': 0x31, # kVK_Space
+        'space': 0x31,
+        '\r': 0x24, # kVK_Return
+        '\n': 0x24, # kVK_Return
+        'enter': 0x24, # kVK_Return
+        'return': 0x24, # kVK_Return
+        '\t': 0x30, # kVK_Tab
+        'tab': 0x30, # kVK_Tab
+        'backspace': 0x33, # kVK_Delete, which is "Backspace" on OS X.
+        '\b': 0x33, # kVK_Delete, which is "Backspace" on OS X.
+        'esc': 0x35, # kVK_Escape
+        'escape': 0x35, # kVK_Escape
+        'command': 0x37, # kVK_Command
+        'shift': 0x38, # kVK_Shift
+        'shiftleft': 0x38, # kVK_Shift
+        'capslock': 0x39, # kVK_CapsLock
+        'option': 0x3a, # kVK_Option
+        'optionleft': 0x3a, # kVK_Option
+        'alt': 0x3a, # kVK_Option
+        'altleft': 0x3a, # kVK_Option
+        'ctrl': 0x3b, # kVK_Control
+        'ctrlleft': 0x3b, # kVK_Control
+        'shiftright': 0x3c, # kVK_RightShift
+        'optionright': 0x3d, # kVK_RightOption
+        'ctrlright': 0x3e, # kVK_RightControl
+        'fn': 0x3f, # kVK_Function
+        'f17': 0x40, # kVK_F17
+        'volumeup': 0x48, # kVK_VolumeUp
+        'volumedown': 0x49, # kVK_VolumeDown
+        'volumemute': 0x4a, # kVK_Mute
+        'f18': 0x4f, # kVK_F18
+        'f19': 0x50, # kVK_F19
+        'f20': 0x5a, # kVK_F20
+        'f5': 0x60, # kVK_F5
+        'f6': 0x61, # kVK_F6
+        'f7': 0x62, # kVK_F7
+        'f3': 0x63, # kVK_F3
+        'f8': 0x64, # kVK_F8
+        'f9': 0x65, # kVK_F9
+        'f11': 0x67, # kVK_F11
+        'f13': 0x69, # kVK_F13
+        'f16': 0x6a, # kVK_F16
+        'f14': 0x6b, # kVK_F14
+        'f10': 0x6d, # kVK_F10
+        'f12': 0x6f, # kVK_F12
+        'f15': 0x71, # kVK_F15
+        'help': 0x72, # kVK_Help
+        'home': 0x73, # kVK_Home
+        'pageup': 0x74, # kVK_PageUp
+        'pgup': 0x74, # kVK_PageUp
+        'del': 0x75, # kVK_ForwardDelete
+        'delete': 0x75, # kVK_ForwardDelete
+        'f4': 0x76, # kVK_F4
+        'end': 0x77, # kVK_End
+        'f2': 0x78, # kVK_F2
+        'pagedown': 0x79, # kVK_PageDown
+        'pgdn': 0x79, # kVK_PageDown
+        'f1': 0x7a, # kVK_F1
+        'left': 0x7b, # kVK_LeftArrow
+        'right': 0x7c, # kVK_RightArrow
+        'down': 0x7d, # kVK_DownArrow
+        'up': 0x7e, # kVK_UpArrow
+        'yen': 0x5d, # kVK_JIS_Yen
+        #'underscore' : 0x5e, # kVK_JIS_Underscore (only applies to Japanese keyboards)
+        #'comma': 0x5f, # kVK_JIS_KeypadComma (only applies to Japanese keyboards)
+        'eisu': 0x66, # kVK_JIS_Eisu
+        'kana': 0x68, # kVK_JIS_Kana
+    })
+
+def _setFrenchLayout():
+    """
+        Use win32api in order to load and set french layout keyboard for current thread only.
+        Reload keymapping after loading new key layout. (AZERTY)
+
+        Args:
+          No argument are needed.
+
+        Returns:
+          None
+    """
+    
+    keyboardMapping.update({
+        'a': 0x0c, # kVK_ANSI_A |
+        's': 0x01, # kVK_ANSI_S |
+        'd': 0x02, # kVK_ANSI_D |
+        'f': 0x03, # kVK_ANSI_F |
+        'h': 0x04, # kVK_ANSI_H |
+        'g': 0x05, # kVK_ANSI_G |
+        'z': 0x0d, # kVK_ANSI_Z |
+        'x': 0x07, # kVK_ANSI_X |
+        'c': 0x08, # kVK_ANSI_C |
+        'v': 0x09, # kVK_ANSI_V |
+        'b': 0x0b, # kVK_ANSI_B |
+        'q': 0x00, # kVK_ANSI_Q |
+        'w': 0x06, # kVK_ANSI_W |
+        'e': 0x0e, # kVK_ANSI_E |
+        'r': 0x0f, # kVK_ANSI_R |
+        'y': 0x10, # kVK_ANSI_Y |
+        't': 0x11, # kVK_ANSI_T |
+        '1': 0x12, # kVK_ANSI_1
+        '&': 0x12, # kVK_ANSI_1
+        '2': 0x13, # kVK_ANSI_2
+        '@': 0x0a, # kVK_ANSI_AROBASE |
+        '#': 0x0a, # kVK_ANSI_AROBASE |
+        '3': 0x14, # kVK_ANSI_3
+        '"': 0x14, # kVK_ANSI_3
+        '4': 0x15, # kVK_ANSI_4
+        '\'': 0x15, # kVK_ANSI_4
+        '6': 0x16, # kVK_ANSI_6
+        #'^': 0x16, # kVK_ANSI_6
+        '5': 0x17, # kVK_ANSI_5
+        '(': 0x17, # kVK_ANSI_5 |
+        '=': 0x2c, # kVK_ANSI_Equal |
+        '+': 0x2c, # kVK_ANSI_Equal |
+        '9': 0x19, # kVK_ANSI_9
+        ')': 0x1b, # kVK_ANSI_9 |
+        '7': 0x1a, # kVK_ANSI_7
+        #'&': 0x12, # kVK_ANSI_7
+        '-': 0x1b, # kVK_ANSI_Minus |
+        '_': 0x1b, # kVK_ANSI_Minus |
+        '8': 0x1c, # kVK_ANSI_8
+        '*': 0x1c, # kVK_ANSI_8
+        '0': 0x1d, # kVK_ANSI_0
+        #')': 0x1d, # kVK_ANSI_0
+        ']': 0x1b, # kVK_ANSI_RightBracket |
+        '}': 0x1b, # kVK_ANSI_RightBracket |
+        'o': 0x1f, # kVK_ANSI_O |
+        'u': 0x20, # kVK_ANSI_U |
+        '[': 0x17, # kVK_ANSI_LeftBracket |
+        '{': 0x17, # kVK_ANSI_LeftBracket |
+        'i': 0x22, # kVK_ANSI_I |
+        'p': 0x23, # kVK_ANSI_P |
+        'l': 0x25, # kVK_ANSI_L |
+        'j': 0x26, # kVK_ANSI_J |
+        "'": 0x27, # kVK_ANSI_Quote
+        '"': 0x27, # kVK_ANSI_Quote
+        'k': 0x28, # kVK_ANSI_K |
+        ';': 0x2b, # kVK_ANSI_Semicolon |
+        ':': 0x2f, # kVK_ANSI_Semicolon |
+        '\\': 0x2f, # kVK_ANSI_Backslash |
+        '|': 0x25, # kVK_ANSI_Backslash |
+        ',': 0x2e, # kVK_ANSI_Comma |
+        '<': 0x32, # kVK_ANSI_Comma
+        '/': 0x2f, # kVK_ANSI_Slash |
+        '?': 0x2e, # kVK_ANSI_Slash |
+        'n': 0x2d, # kVK_ANSI_N |
+        'm': 0x29, # kVK_ANSI_M |
+        '.': 0x2b, # kVK_ANSI_Period |
+        '>': 0x32, # kVK_ANSI_Period
+        '`': 0x32, # kVK_ANSI_Grave
+        '~': 0x32, # kVK_ANSI_Grave
+        ' ': 0x31, # kVK_Space
+        'space': 0x31,
+        '\r': 0x24, # kVK_Return
+        '\n': 0x24, # kVK_Return
+        'enter': 0x24, # kVK_Return
+        'return': 0x24, # kVK_Return
+        '\t': 0x30, # kVK_Tab
+        'tab': 0x30, # kVK_Tab
+        'backspace': 0x33, # kVK_Delete, which is "Backspace" on OS X.
+        '\b': 0x33, # kVK_Delete, which is "Backspace" on OS X.
+        'esc': 0x35, # kVK_Escape
+        'escape': 0x35, # kVK_Escape
+        'command': 0x37, # kVK_Command
+        'shift': 0x38, # kVK_Shift
+        'shiftleft': 0x38, # kVK_Shift
+        'capslock': 0x39, # kVK_CapsLock
+        'option': 0x3a, # kVK_Option
+        'optionleft': 0x3a, # kVK_Option
+        'alt': 0x3a, # kVK_Option
+        'altleft': 0x3a, # kVK_Option
+        'ctrl': 0x3b, # kVK_Control
+        'ctrlleft': 0x3b, # kVK_Control
+        'shiftright': 0x3c, # kVK_RightShift
+        'optionright': 0x3d, # kVK_RightOption
+        'ctrlright': 0x3e, # kVK_RightControl
+        'fn': 0x3f, # kVK_Function
+        'f17': 0x40, # kVK_F17
+        'volumeup': 0x48, # kVK_VolumeUp
+        'volumedown': 0x49, # kVK_VolumeDown
+        'volumemute': 0x4a, # kVK_Mute
+        'f18': 0x4f, # kVK_F18
+        'f19': 0x50, # kVK_F19
+        'f20': 0x5a, # kVK_F20
+        'f5': 0x60, # kVK_F5
+        'f6': 0x61, # kVK_F6
+        'f7': 0x62, # kVK_F7
+        'f3': 0x63, # kVK_F3
+        'f8': 0x64, # kVK_F8
+        'f9': 0x65, # kVK_F9
+        'f11': 0x67, # kVK_F11
+        'f13': 0x69, # kVK_F13
+        'f16': 0x6a, # kVK_F16
+        'f14': 0x6b, # kVK_F14
+        'f10': 0x6d, # kVK_F10
+        'f12': 0x6f, # kVK_F12
+        'f15': 0x71, # kVK_F15
+        'help': 0x72, # kVK_Help
+        'home': 0x73, # kVK_Home
+        'pageup': 0x74, # kVK_PageUp
+        'pgup': 0x74, # kVK_PageUp
+        'del': 0x75, # kVK_ForwardDelete
+        'delete': 0x75, # kVK_ForwardDelete
+        'f4': 0x76, # kVK_F4
+        'end': 0x77, # kVK_End
+        'f2': 0x78, # kVK_F2
+        'pagedown': 0x79, # kVK_PageDown
+        'pgdn': 0x79, # kVK_PageDown
+        'f1': 0x7a, # kVK_F1
+        'left': 0x7b, # kVK_LeftArrow
+        'right': 0x7c, # kVK_RightArrow
+        'down': 0x7d, # kVK_DownArrow
+        'up': 0x7e, # kVK_UpArrow
+        'yen': 0x5d, # kVK_JIS_Yen
+        #'underscore' : 0x5e, # kVK_JIS_Underscore (only applies to Japanese keyboards)
+        #'comma': 0x5f, # kVK_JIS_KeypadComma (only applies to Japanese keyboards)
+        'eisu': 0x66, # kVK_JIS_Eisu
+        'kana': 0x68, # kVK_JIS_Kana
+    })
+
 def _keyDown(key):
     if key not in keyboardMapping or keyboardMapping[key] is None:
         return

--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -5,6 +5,7 @@
 import ctypes
 import ctypes.wintypes
 import pyautogui
+import win32api
 
 import sys
 if sys.platform !=  'win32':
@@ -251,10 +252,48 @@ keyboardMapping.update({
     #'': 0xfe, # VK_OEM_CLEAR
 })
 
+enableFrenchLayout = False
+keysAltFR = ['\\', '#', '~', '{', '[', '|', '`', '^', '@', ']', '}']
+keysShiftFR = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '/', '?', '°', '+', '£', '.', '>']
+
+
 # Populate the basic printable ascii characters.
 for c in range(32, 128):
     keyboardMapping[chr(c)] = ctypes.windll.user32.VkKeyScanA(ctypes.wintypes.WCHAR(chr(c)))
 
+def _setFrenchLayout():
+    """
+        Use win32api in order to load and set french layout keyboard for current thread only.
+        Reload keymapping after loading new key layout. (AZERTY)
+
+        Args:
+          No argument are needed.
+
+        Returns:
+          None
+    """
+    win32api.LoadKeyboardLayout('67896332', 1)
+    ctypes.windll.user32.ActivateKeyboardLayout(1, 8)
+    for c in range(32, 128):
+        keyboardMapping[chr(c)] = ctypes.windll.user32.VkKeyScanA(ctypes.wintypes.WCHAR(chr(c)))
+    enableFrenchLayout = True
+
+def _setEnglishLayout():
+    """
+        Use win32api in order to load and set english layout keyboard for current thread only.
+        Reload keymapping after loading new key layout. (QWERTY)
+
+        Args:
+          No argument are needed.
+
+        Returns:
+          None
+    """
+    win32api.LoadKeyboardLayout('00000409', 1)
+    ctypes.windll.user32.ActivateKeyboardLayout(1, 8)
+    for c in range(32, 128):
+        keyboardMapping[chr(c)] = ctypes.windll.user32.VkKeyScanA(ctypes.wintypes.WCHAR(chr(c)))
+    enableFrenchLayout = False
 
 def _keyDown(key):
     """Performs a keyboard key press without the release. This will put that
@@ -273,7 +312,17 @@ def _keyDown(key):
     if key not in keyboardMapping or keyboardMapping[key] is None:
         return
 
-    needsShift = pyautogui.isShiftCharacter(key)
+    if enableFrenchLayout:
+        if key in keysAltFR:
+            needsLeftAlt = True
+        else:
+            needsLeftAlt = False
+        if key in keysShiftFR:
+            needsShift = True
+        else:
+            needsShift = False
+    else:
+        needsShift = pyautogui.isShiftCharacter(key)
 
     """
     # OLD CODE: The new code relies on having all keys be loaded in keyboardMapping from the start.
@@ -290,15 +339,22 @@ def _keyDown(key):
     """
 
     vkCode = keyboardMapping[key]
-    if vkCode > 0x100: # the vk code will be > 0x100 if it needs shift
-        vkCode -= 0x100
-        needsShift = True
+    #Only needed by english layout keyboard
+    if enableFrenchLayout == False:
+        if vkCode > 0x100: # the vk code will be > 0x100 if it needs shift
+            vkCode -= 0x100
+            needsShift = True
 
     if needsShift:
         ctypes.windll.user32.keybd_event(0x10, 0, 0, 0) # 0x10 is VK_SHIFT
+    if needsLeftAlt:
+        ctypes.windll.user32.keybd_event(0xa5, 0, 0, 0) #0xa5 is VK_RMENU
+
     ctypes.windll.user32.keybd_event(vkCode, 0, 0, 0)
     if needsShift:
         ctypes.windll.user32.keybd_event(0x10, 0, KEYEVENTF_KEYUP, 0) # 0x10 is VK_SHIFT
+    if needsLeftAlt:
+        ctypes.windll.user32.keybd_event(0xa5, 0, KEYEVENTF_KEYUP, 0) #0xa5 is VK_RMENU
 
 
 def _keyUp(key):
@@ -314,7 +370,7 @@ def _keyUp(key):
     if key not in keyboardMapping or keyboardMapping[key] is None:
         return
 
-    needsShift = pyautogui.isShiftCharacter(key)
+    #needsShift = pyautogui.isShiftCharacter(key)
     """
     # OLD CODE: The new code relies on having all keys be loaded in keyboardMapping from the start.
     if key in keyboardMapping.keys():
@@ -329,15 +385,19 @@ def _keyUp(key):
             needsShift = True
     """
     vkCode = keyboardMapping[key]
-    if vkCode > 0x100: # the vk code will be > 0x100 if it needs shift
-        vkCode -= 0x100
-        needsShift = True
 
-    if needsShift:
-        ctypes.windll.user32.keybd_event(0x10, 0, 0, 0) # 0x10 is VK_SHIFT
+    if enableFrenchLayout == False and vkCode > 0x100:
+        vkCode -= 0x100
+
+    #if vkCode > 0x100: # the vk code will be > 0x100 if it needs shift
+        #vkCode -= 0x100
+        #needsShift = True
+
+    #if needsShift:
+        #ctypes.windll.user32.keybd_event(0x10, 0, 0, 0) # 0x10 is VK_SHIFT
     ctypes.windll.user32.keybd_event(vkCode, 0, KEYEVENTF_KEYUP, 0)
-    if needsShift:
-        ctypes.windll.user32.keybd_event(0x10, 0, KEYEVENTF_KEYUP, 0) # 0x10 is VK_SHIFT
+    #if needsShift:
+        #ctypes.windll.user32.keybd_event(0x10, 0, KEYEVENTF_KEYUP, 0) # 0x10 is VK_SHIFT
 
 
 def _position():

--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -321,6 +321,9 @@ def _keyDown(key):
             needsShift = True
         else:
             needsShift = False
+        
+        if (key >= 'A' and key <= 'Z'):
+            needsShift = True
     else:
         needsShift = pyautogui.isShiftCharacter(key)
 

--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -256,7 +256,6 @@ enableFrenchLayout = False
 keysAltFR = ['\\', '#', '~', '{', '[', '|', '`', '^', '@', ']', '}']
 keysShiftFR = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '/', '?', '°', '+', '£', '.', '>']
 
-
 # Populate the basic printable ascii characters.
 for c in range(32, 128):
     keyboardMapping[chr(c)] = ctypes.windll.user32.VkKeyScanA(ctypes.wintypes.WCHAR(chr(c)))
@@ -272,6 +271,7 @@ def _setFrenchLayout():
         Returns:
           None
     """
+    global enableFrenchLayout
     win32api.LoadKeyboardLayout('67896332', 1)
     ctypes.windll.user32.ActivateKeyboardLayout(1, 8)
     for c in range(32, 128):
@@ -289,6 +289,7 @@ def _setEnglishLayout():
         Returns:
           None
     """
+    global enableFrenchLayout
     win32api.LoadKeyboardLayout('00000409', 1)
     ctypes.windll.user32.ActivateKeyboardLayout(1, 8)
     for c in range(32, 128):
@@ -312,6 +313,9 @@ def _keyDown(key):
     if key not in keyboardMapping or keyboardMapping[key] is None:
         return
 
+    needsLeftAlt = False
+    needsShift = False
+
     if enableFrenchLayout:
         if key in keysAltFR:
             needsLeftAlt = True
@@ -321,7 +325,7 @@ def _keyDown(key):
             needsShift = True
         else:
             needsShift = False
-        
+
         if (key >= 'A' and key <= 'Z'):
             needsShift = True
     else:


### PR DESCRIPTION
# Support for AZERTY

Many people are willing to use pyautogui with foreign keyboard layout, that why I intended to propose this update. I, for example, created a project destined for French users.I was unable to use this tool properly without these modifications.

**Functions added**
  - setKeyboardLayout(target) 

    Change keyboard layout, needed for OSX and Windows operating system.
    NOTE: Support for QWERTY and AZERTY only

Reminder: If setKeyboardLayout is not called, qwerty is selected by default. This function is optional.
This function is does nothing on Linux O.S.

By the way, thank for this very good job, asweigart! 