### PR TITLE
Format install commands

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,28 +8,28 @@ To install PyAutoGUI, install the `pyautogui` package from PyPI and dependencies
 
 On Windows, this is:
 
-    C:\Python34\pip.exe install pyautogui
+    ``C:\Python34\pip.exe install pyautogui``
 
 (Though you may have a different version of Python installed other than 3.4)
 
 On OS X, this is:
 
-    sudo pip3 install pyobjc-core
+    ``sudo pip3 install pyobjc-core``
 
-    sudo pip3 install pyobjc
+    ``sudo pip3 install pyobjc``
 
-    sudo pip3 install pyautogui
+    ``sudo pip3 install pyautogui``
 
 On Linux, this is:
 
-    sudo pip3 install python3-xlib
+    ``sudo pip3 install python3-xlib``
 
-    sudo apt-get scrot
+    ``sudo apt-get scrot``
 
-    sudo apt-get install python-tk
+    ``sudo apt-get install python-tk``
 
-    sudo apt-get install python3-dev
+    ``sudo apt-get install python3-dev``
 
-    sudo pip3 install pyautogui
+    ``sudo pip3 install pyautogui``
 
 PyAutoGUI will try to install Pillow (for its screenshot capabilities). This happens when pip installs PyAutoGUI.

--- a/docs/msgbox.rst
+++ b/docs/msgbox.rst
@@ -32,5 +32,5 @@ The password() Function
 
     >>> password(text='', title='', default='', mask='*')
 
-Displays a message box with text input, and OK & Cancel buttons. Typed characters appear as *. Returns the text entered, or None if Cancel was clicked.
+Displays a message box with text input, and OK & Cancel buttons. Typed characters appear as ``*``. Returns the text entered, or None if Cancel was clicked.
 


### PR DESCRIPTION
The documented installation commands, unlike nearly all of the sample code in the docs, is formatted as regular paragraph text, instead of literals. This pull request reformats the installation commands as literals. I think this helps the readability of the install doc.

Please note that this fixes the problem that PR #56 fixes, though with a slightly different approach.

Finally, the second commit in this PR fixes an unrelated build warning, as I assumed it was in poor taste to submit a PR with a build warning. If you'd like me to submit a fix for that separately, please let me know and I can update my branch. Thanks!