### PR TITLE
OSX: fix for doubleclick and dragging 

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -651,7 +651,7 @@ def moveRel(xOffset=None, yOffset=None, duration=0.0, tween=linear, pause=None, 
     _autoPause(pause, _pause)
 
 
-def dragTo(x=None, y=None, duration=0.0, tween=linear, button='left', pause=None, _pause=True):
+def dragTo(x=None, y=None, duration=0.0, tween=linear, button='left', pause=None, _pause=True, mouseDownUp=True):
     """Performs a mouse drag (mouse movement while a button is held down) to a
     point on the screen.
 
@@ -674,6 +674,8 @@ def dragTo(x=None, y=None, duration=0.0, tween=linear, button='left', pause=None
       button (str, int, optional): The mouse button clicked. Must be one of
         'left', 'middle', 'right' (or 1, 2, or 3) respectively. 'left' by
         default.
+      mouseDownUp (True, False): When true, the mouseUp/Down actions are not perfomed.
+        Which allows dragging over multiple (small) actions. 'True' by default.
 
     Returns:
       None
@@ -681,14 +683,16 @@ def dragTo(x=None, y=None, duration=0.0, tween=linear, button='left', pause=None
     _failSafeCheck()
     if type(x) in (tuple, list):
         x, y = x[0], x[1]
-    mouseDown(button=button, _pause=False)
+    if mouseDownUp:
+        mouseDown(button=button, _pause=False)
     _mouseMoveDrag('drag', x, y, 0, 0, duration, tween, button)
-    mouseUp(button=button, _pause=False)
+    if mouseDownUp:
+        mouseUp(button=button, _pause=False)
 
     _autoPause(pause, _pause)
 
 
-def dragRel(xOffset=0, yOffset=0, duration=0.0, tween=linear, button='left', pause=None, _pause=True):
+def dragRel(xOffset=0, yOffset=0, duration=0.0, tween=linear, button='left', pause=None, _pause=True, mouseDownUp=True):
     """Performs a mouse drag (mouse movement while a button is held down) to a
     point on the screen, relative to its current position.
 
@@ -711,7 +715,9 @@ def dragRel(xOffset=0, yOffset=0, duration=0.0, tween=linear, button='left', pau
       button (str, int, optional): The mouse button clicked. Must be one of
         'left', 'middle', 'right' (or 1, 2, or 3) respectively. 'left' by
         default.
-
+      mouseDownUp (True, False): When true, the mouseUp/Down actions are not perfomed.
+        Which allows dragging over multiple (small) actions. 'True' by default.
+        
     Returns:
       None
     """
@@ -729,9 +735,11 @@ def dragRel(xOffset=0, yOffset=0, duration=0.0, tween=linear, button='left', pau
     _failSafeCheck()
 
     mousex, mousey = platformModule._position()
-    mouseDown(button=button, _pause=False)
+    if mouseDownUp:
+        mouseDown(button=button, _pause=False)
     _mouseMoveDrag('drag', mousex, mousey, xOffset, yOffset, duration, tween, button)
-    mouseUp(button=button, _pause=False)
+    if mouseDownUp:
+        mouseUp(button=button, _pause=False)
 
     _autoPause(pause, _pause)
 

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -456,7 +456,14 @@ def doubleClick(x=None, y=None, interval=0.0, button='left', duration=0.0, tween
     """
     _failSafeCheck()
 
-    click(x, y, 2, interval, button, _pause=False)
+    # Multiple clicks work different in OSX
+    if sys.platform == 'darwin':
+        x, y = _unpackXY(x, y)
+        _mouseMoveDrag('move', x, y, 0, 0, duration=0, tween=None)
+        x, y = platformModule._position()
+        platformModule._multiclick(x, y, button, 2)
+    else:
+        click(x, y, 2, interval, button, _pause=False)
 
     _autoPause(pause, _pause)
 
@@ -492,8 +499,14 @@ def tripleClick(x=None, y=None, interval=0.0, button='left', duration=0.0, tween
     """
     _failSafeCheck()
 
-    click(x, y, 3, interval, button, _pause=False)
-
+    # Multiple clicks work different in OSX
+    if sys.platform == 'darwin':
+        x, y = _unpackXY(x, y)
+        _mouseMoveDrag('move', x, y, 0, 0, duration=0, tween=None)
+        x, y = platformModule._position()
+        platformModule._multiclick(x, y, button, 3)
+    else:
+        click(x, y, 2, interval, button, _pause=False)
     _autoPause(pause, _pause)
 
 

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -461,7 +461,7 @@ def doubleClick(x=None, y=None, interval=0.0, button='left', duration=0.0, tween
         x, y = _unpackXY(x, y)
         _mouseMoveDrag('move', x, y, 0, 0, duration=0, tween=None)
         x, y = platformModule._position()
-        platformModule._multiclick(x, y, button, 2)
+        platformModule._multiClick(x, y, button, 2)
     else:
         click(x, y, 2, interval, button, _pause=False)
 
@@ -504,7 +504,7 @@ def tripleClick(x=None, y=None, interval=0.0, button='left', duration=0.0, tween
         x, y = _unpackXY(x, y)
         _mouseMoveDrag('move', x, y, 0, 0, duration=0, tween=None)
         x, y = platformModule._position()
-        platformModule._multiclick(x, y, button, 3)
+        platformModule._multiClick(x, y, button, 3)
     else:
         click(x, y, 2, interval, button, _pause=False)
     _autoPause(pause, _pause)

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -399,7 +399,7 @@ def _dragTo(x, y, button):
         _sendMouseEvent(Quartz.kCGEventRightMouseDragged , x, y, Quartz.kCGMouseButtonRight)
     else:
         assert False, "button argument not in ('left', 'middle', 'right')"
-
+    time.sleep(0.01) # needed to allow OS time to catch up.
 
 def _moveTo(x, y):
     _sendMouseEvent(Quartz.kCGEventMouseMoved, x, y, 0)

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -384,6 +384,38 @@ def _click(x, y, button):
     else:
         assert False, "button argument not in ('left', 'middle', 'right')"
 
+def _multiclick(x, y, button, num):
+    btn    = None
+    down   = None
+    up     = None
+    
+    if button == 'left':
+        btn  = Quartz.kCGMouseButtonLeft
+        down = Quartz.kCGEventLeftMouseDown
+        up   = Quartz.kCGEventLeftMouseUp
+    elif button == 'middle':
+        btn  = Quartz.kCGMouseButtonCenter
+        down = Quartz.kCGEventOtherMouseDown
+        up   = Quartz.kCGEventOtherMouseUp        
+    elif button == 'right':
+        btn  = Quartz.kCGMouseButtonRight
+        down = Quartz.kCGEventRightMouseDown
+        up   = Quartz.kCGEventRightMouseUp     
+    else:
+        assert False, "button argument not in ('left', 'middle', 'right')"
+        return
+    
+    mouseEvent = Quartz.CGEventCreateMouseEvent(None, down, (x, y), btn)
+    Quartz.CGEventSetIntegerValueField(mouseEvent, Quartz.kCGMouseEventClickState, num)
+    Quartz.CGEventPost(Quartz.kCGHIDEventTap, mouseEvent)
+    Quartz.CGEventSetType(mouseEvent, up)
+    Quartz.CGEventPost(Quartz.kCGHIDEventTap, mouseEvent)
+    for i in range(0, num-1):
+        Quartz.CGEventSetType(mouseEvent, down)
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, mouseEvent)
+        Quartz.CGEventSetType(mouseEvent, up) 
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, mouseEvent)
+
 
 def _sendMouseEvent(ev, x, y, button):
     mouseEvent = Quartz.CGEventCreateMouseEvent(None, ev, (x, y), button)
@@ -404,3 +436,4 @@ def _dragTo(x, y, button):
 def _moveTo(x, y):
     _sendMouseEvent(Quartz.kCGEventMouseMoved, x, y, 0)
     time.sleep(0.01) # needed to allow OS time to catch up.
+

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -384,7 +384,7 @@ def _click(x, y, button):
     else:
         assert False, "button argument not in ('left', 'middle', 'right')"
 
-def _multiclick(x, y, button, num):
+def _multiClick(x, y, button, num):
     btn    = None
     down   = None
     up     = None


### PR DESCRIPTION
These 4 commits solve the following issues:

General:
2dede35: enables calling multiple dragRel functions with small and large dx/dy in sequence. Previously, dragging lost track when using multiple calls as the OS could not follow the speed.

OSX
dce333d: added 0.01 delay for the OS to catch up in _dragTo. (similar to _moveTo)
a655757 and 14e2ad0 : fixed multi-click support by adding a new function. The calls to 'doubleClick' and 'tripleClick' now function as expected. 'click' with 'click=<num>' just executes <num> single clicks.

This PR fixes issue #71

Edit: As noted at several places, the window in which a double click should be performed has to be active/in-focus! So, in order to use a double click properly: 
1. Focus window 
1. Perform double/multi click in this window
