### PR TITLE
Fixed typos

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,9 +24,9 @@ On Linux, this is:
 
     ``sudo pip3 install python3-xlib``
 
-    ``sudo apt-get scrot``
+    ``sudo apt-get install scrot``
 
-    ``sudo apt-get install python-tk``
+    ``sudo apt-get install python3-tk``
 
     ``sudo apt-get install python3-dev``
 


### PR DESCRIPTION
There was a missing word (```install```) in ```sudo apt-get install scrot``` and changed ```sudo apt-get install python-tk``` to ```sudo apt-get install python3-tk``` so ```sudo pip3 install pyautogui``` no longer fails.