### PR TITLE
By pass PermissionError [WinError 5]

### DIFF
--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -390,11 +390,20 @@ def _mouseDown(x, y, button):
       None
     """
     if button == 'left':
-        _sendMouseEvent(MOUSEEVENTF_LEFTDOWN, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_LEFTDOWN, x, y)
+        except PermissionError:
+            pass        
     elif button == 'middle':
-        _sendMouseEvent(MOUSEEVENTF_MIDDLEDOWN, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_MIDDLEDOWN, x, y)
+        except PermissionError:
+            pass
     elif button == 'right':
-        _sendMouseEvent(MOUSEEVENTF_RIGHTDOWN, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_RIGHTDOWN, x, y)
+        except PermissionError:
+            pass
     else:
         assert False, "button argument not in ('left', 'middle', 'right')"
 
@@ -412,11 +421,20 @@ def _mouseUp(x, y, button):
       None
     """
     if button == 'left':
-        _sendMouseEvent(MOUSEEVENTF_LEFTUP, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_LEFTUP, x, y)
+        except PermissionError:
+            pass
     elif button == 'middle':
-        _sendMouseEvent(MOUSEEVENTF_MIDDLEUP, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_MIDDLEUP, x, y)
+        except PermissionError:
+            pass
     elif button == 'right':
-        _sendMouseEvent(MOUSEEVENTF_RIGHTUP, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_RIGHTUP, x, y)
+        except PermissionError:
+            pass
     else:
         assert False, "button argument not in ('left', 'middle', 'right')"
 
@@ -434,11 +452,20 @@ def _click(x, y, button):
       None
     """
     if button == 'left':
-        _sendMouseEvent(MOUSEEVENTF_LEFTCLICK, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_LEFTCLICK, x, y)
+        except PermissionError:
+            pass
     elif button == 'middle':
-        _sendMouseEvent(MOUSEEVENTF_MIDDLECLICK, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_MIDDLECLICK, x, y)
+        except PermissionError:
+            pass
     elif button == 'right':
-        _sendMouseEvent(MOUSEEVENTF_RIGHTCLICK, x, y)
+        try: # Using "try" in order to avoid PermissionError [WinError 5]
+            _sendMouseEvent(MOUSEEVENTF_RIGHTCLICK, x, y)
+        except PermissionError:
+            pass
     else:
         assert False, "button argument not in ('left', 'middle', 'right')"
 
@@ -511,7 +538,10 @@ def _scroll(clicks, x=None, y=None):
         elif y >= height:
             y = height - 1
 
-    _sendMouseEvent(MOUSEEVENTF_WHEEL, x, y, dwData=clicks)
+    try: # Using "try" in order to avoid PermissionError [WinError 5]
+        _sendMouseEvent(MOUSEEVENTF_WHEEL, x, y, dwData=clicks)
+    except PermissionError:
+            pass
 
 
 def _hscroll(clicks, x, y):


### PR DESCRIPTION
We have had many cases in Windows 7, Windows 8 and Windows 10 with Windows permission error when we try send a mouse command. Based on "The click function returns PermissionError [WinError 5] #60" issue I suggest this modifications.
