### PR TITLE
add missing pyautogui to keyDown and keyUp in cheatsheet

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -90,8 +90,8 @@ Keyboard hotkeys like Ctrl-S or Ctrl-Shift-1 can be done by passing a list of ke
 
 Individual button down and up events can be called separately:
 
-    >>> keyDown(key_name)
-    >>> keyUp(key_name)
+    >>> pyautogui.keyDown(key_name)
+    >>> pyautogui.keyUp(key_name)
 
 
 Message Box Functions


### PR DESCRIPTION
the cheatsheet for keyDown and keyUp are missing the pyautogui module.

https://pyautogui.readthedocs.io/en/latest/cheatsheet.html#keyboard-functions

this commit adds the module.

```
  Individual button down and up events can be called separately:
 
-    >>> keyDown(key_name)
-    >>> keyUp(key_name)
+    >>> pyautogui.keyDown(key_name)
+    >>> pyautogui.keyUp(key_name) 
```