### PR TITLE
Added the `space` keyboard key to the docs

### DIFF
--- a/docs/keyboard.rst
+++ b/docs/keyboard.rst
@@ -95,7 +95,7 @@ The following are the valid strings to pass to the ``press()``, ``keyDown()``, `
     'num7', 'num8', 'num9', 'numlock', 'pagedown', 'pageup', 'pause', 'pgdn',
     'pgup', 'playpause', 'prevtrack', 'print', 'printscreen', 'prntscrn',
     'prtsc', 'prtscr', 'return', 'right', 'scrolllock', 'select', 'separator',
-    'shift', 'shiftleft', 'shiftright', 'sleep', 'stop', 'subtract', 'tab',
+    'shift', 'shiftleft', 'shiftright', 'sleep', 'space', 'stop', 'subtract', 'tab',
     'up', 'volumedown', 'volumemute', 'volumeup', 'win', 'winleft', 'winright', 'yen',
     'command', 'option', 'optionleft', 'optionright']
 


### PR DESCRIPTION
The key seems to be supported but it wasn't in the documentation
