### PR TITLE
Fixes pyautogui.tweens.easeInOutQuad reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Keyboard and Mouse Control
     >>> pyautogui.click()
     >>> pyautogui.moveRel(None, 10)  # move mouse 10 pixels down
     >>> pyautogui.doubleClick()
-    >>> pyautogui.moveTo(500, 500, duration=2, tween=pyautogui.tweens.easeInOutQuad)  # use tweening/easing function to move mouse over 2 seconds.
+    >>> pyautogui.moveTo(500, 500, duration=2, tween=pyautogui.easeInOutQuad)  # use tweening/easing function to move mouse over 2 seconds.
     >>> pyautogui.typewrite('Hello world!', interval=0.25)  # type with quarter-second pause in between each key
     >>> pyautogui.press('esc')
     >>> pyautogui.keyDown('shift')


### PR DESCRIPTION
Fixes pyautogui.tweens.easeInOutQuad reference in README: 

```bash
AttributeError: 'module' object has no attribute 'tweens'
```
