### PR TITLE
Fix install failing on Windows XP

### DIFF
--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -12,7 +12,10 @@ if sys.platform !=  'win32':
 
 
 # Fixes the scaling issues where PyAutoGUI was reporting the wrong resolution:
-ctypes.windll.user32.SetProcessDPIAware()
+try:
+   ctypes.windll.user32.SetProcessDPIAware()
+except AttributeError:
+    pass
 
 
 """


### PR DESCRIPTION
The API `SetProcessDPIAware` does not exist on Windows XP.