### PR TITLE
Avoid module init on build/install

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -30,7 +30,7 @@ You will need PIL/Pillow to use the screenshot features.
 from __future__ import absolute_import, division, print_function
 
 
-__version__ = '0.9.36'
+from pyautogui._version import __version__
 
 import collections
 import sys

--- a/pyautogui/_version.py
+++ b/pyautogui/_version.py
@@ -1,0 +1,3 @@
+"""The version for PyAutoGUI"""
+
+__version__ = '0.9.36'

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,17 @@
+import os
 from setuptools import setup
 
 
+__version__ = ""
+version_file = os.path.join(os.path.split(__file__)[0], "pyautogui", "_version.py")
+with open(version_file) as module:
+    # execute the code in version.py to populate __version__ variable
+    # this way, a race condition on sdist or install is avoided
+    exec(compile(module.read(), version_file, 'exec'))
+
 setup(
     name='PyAutoGUI',
-    version=__import__('pyautogui').__version__,
+    version=__version__,
     url='https://github.com/asweigart/pyautogui',
     author='Al Sweigart',
     author_email='al@inventwithpython.com',


### PR DESCRIPTION
Hi, we are looking to add `pyautogui` as a dependency to our own testing toolbox. Unfortunately, the build process is not straightforward as the import of the version string in `setup.py` invokes module init because of the import of the `__version__`string. This breaks the installation in headless environments (e.g. in our daily builds on Jenkins).
The proposed change fixes installation issues in headless environments (examples: #78, #101).
I also configured and ran some [test builds on travis](https://travis-ci.org/hoefling/pyautogui/builds/250556941) to verify the patches work for different python versions on linux and OSX.