### PR TITLE
Add platform-specific dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,8 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4'
     ],
+    extras_require={
+        ':sys_platform == "darwin"': ['pyobjc', 'pyobjc-core'],
+        ':"linux" in sys_platform': ['python3-xlib'],
+    },
 )


### PR DESCRIPTION
Another suggestion is to add platform-specific dependencies in the setup script. This way, 
* the user is not required to perform additional steps on installation as all python dependencies will be installed by `pip`/`easy_install`;
* the `PyAutoGUI` package can be safely used as a dependency in another packages.

The proposed change fixes issues when platform-specific dependencies are not installed via `pip` before the actual installation (example: #96).