### PR TITLE
Small fix: menu key for Linux.

### DIFF
--- a/pyautogui/_pyautogui_x11.py
+++ b/pyautogui/_pyautogui_x11.py
@@ -203,7 +203,7 @@ keyboardMapping.update({
     'help':              _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Help')),
     'winleft':           _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Super_L')),
     'winright':          _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Super_R')),
-    'apps':              _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Super_L')),
+    'apps':              _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Menu')),
     'num0':              _display.keysym_to_keycode(Xlib.XK.string_to_keysym('KP_0')),
     'num1':              _display.keysym_to_keycode(Xlib.XK.string_to_keysym('KP_1')),
     'num2':              _display.keysym_to_keycode(Xlib.XK.string_to_keysym('KP_2')),


### PR DESCRIPTION
Menu key had incorrect String (and consequently keysym and keycode).