### PR TITLE
Simple fix to support multi-monitor systems

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -793,18 +793,12 @@ def _mouseMoveDrag(moveOrDrag, x, y, xOffset, yOffset, duration, tween=linear, b
     x += xOffset
     y += yOffset
 
-    width, height = size()
-
-    # Make sure x and y are within the screen bounds.
-    x = max(0, min(x, width - 1))
-    y = max(0, min(y, height - 1))
-
     # If the duration is small enough, just move the cursor there instantly.
     steps = [(x, y)]
 
     if duration > MINIMUM_DURATION:
         # Non-instant moving/dragging involves tweening:
-        num_steps = max(width, height)
+        num_steps = max(size())
         sleep_amount = duration / num_steps
         if sleep_amount < MINIMUM_SLEEP:
             num_steps = int(duration / MINIMUM_SLEEP)


### PR DESCRIPTION
Removed coordinate truncation for mouse move to support multi-monitor systems

Current truncation assumes maximum coordinates are x == y == 0, and relies on
size() to get maximum screen coordinates. Both assumptions are violated on
multi-screen systems. The simplest solution (implemented here) is just to drop
truncation. A more complete solution would require a better description of the
screen coordinate system (e.g. [left, top, width, height], or a screen limits
polygon).