### PR TITLE
Fix special key event getting ignored.

### DIFF
--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -217,20 +217,19 @@ special_key_translate_table = {
 }
 
 def _keyDown(key):
-    if key not in keyboardMapping or keyboardMapping[key] is None:
-        return
-
     if key in special_key_translate_table:
         _specialKeyEvent(key, 'down')
+    elif key not in keyboardMapping or keyboardMapping[key] is None:
+        return
     else:
         _normalKeyEvent(key, 'down')
 
-def _keyUp(key):
-    if key not in keyboardMapping or keyboardMapping[key] is None:
-        return
 
+def _keyUp(key):
     if key in special_key_translate_table:
         _specialKeyEvent(key, 'up')
+    elif key not in keyboardMapping or keyboardMapping[key] is None:
+        return
     else:
         _normalKeyEvent(key, 'up')
 


### PR DESCRIPTION
The old if statements ignore special keys since it's in special_key_translate_table but NOT in keyboardMapping