### PR TITLE
Added functions for detecting mouse events for Unix X11 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,17 @@ The locateCenterOnScreen() function returns the center of this match region:
     (1441, 582)
     >>> pyautogui.click(buttonx, buttony)  # clicks the center of where the button was found
 ```
+
+
+Mouse Event Detection (Unix X11 Only)
+--------------------------
+```python
+    >>>import pyautogui
+    >>>print('press left mouse button')
+    >>>pyautogui.waitForMouseEvent('left_down')
+    >>>print('you did it!')
+    >>>while(pyautogui.getMouseEvent() != 'left_up'):
+    >>>     print('now leave the button to stop me')
+    >>>print('it works!')
+
+```

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -835,6 +835,20 @@ def _mouseMoveDrag(moveOrDrag, x, y, xOffset, yOffset, duration, tween=linear, b
     _failSafeCheck()
 
 
+    
+def getMouseEvent():
+    if sys.platform.startswith('java') or sys.platform == 'darwin' or sys.platform == 'win32':
+        raise NotImplementedError('PyAutoGUI catch mouse events only for UNIX that supports X11.')
+    
+    return platformModule._getMouseEvent()
+
+def waitForMouseEvent(e):
+    if sys.platform.startswith('java') or sys.platform == 'darwin' or sys.platform == 'win32':
+        raise NotImplementedError('PyAutoGUI catch mouse events only supported for X11.')
+    
+    return platformModule._waitForMouseEvent(e)
+
+
 # Keyboard Functions
 # ==================
 

--- a/pyautogui/_pyautogui_x11.py
+++ b/pyautogui/_pyautogui_x11.py
@@ -11,6 +11,8 @@ import Xlib.XK
 
 BUTTON_NAME_MAPPING = {'left': 1, 'middle': 2, 'right': 3, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7}
 
+MOUSE_EVENT = {1 : 'left', 2 : 'middle', 3 : 'right'}
+
 
 if sys.platform in ('java', 'darwin', 'win32'):
     raise Exception('The pyautogui_x11 module should only be loaded on a Unix system that supports X11.')
@@ -94,7 +96,44 @@ def _mouseUp(x, y, button):
     button = BUTTON_NAME_MAPPING[button]
     fake_input(_display, X.ButtonRelease, button)
     _display.sync()
+    
+def _getMouseEvent():
+    screen = _display.screen()
+    window = screen.root
+    window.grab_pointer(1, X.PointerMotionMask|X.ButtonReleaseMask|X.ButtonPressMask, X.GrabModeAsync, X.GrabModeAsync, X.NONE, X.NONE, X.CurrentTime)
+    e = _display.next_event()
+    _display.ungrab_pointer(X.CurrentTime)
+    _display.flush()
+    
+    if e.type == X.ButtonPress:
+        e = MOUSE_EVENT[e.detail] + '_down'
+        
+    elif e.type == X.ButtonRelease:
+        e = MOUSE_EVENT[e.detail] + '_up'
+        
+    else:
+        e = 'moving'
+          
+    return e
 
+def _waitForMouseEvent(e):
+    
+    assert e in ['left_down', 'right_down', 'middle_down', 'left_up', 'middle_up', 'right_up', 'moving'], "Event can only be 'left_down', 'right_down', 'middle_down', 'left_up', 'middle_up', 'right_up', 'moving'"
+    
+    while(True):
+        ee = _getMouseEvent()
+        _ee = ee.split('_')
+        
+        if len(_ee) == 2:
+            x, y = _position()
+            if _ee[1] == 'down':
+                _mouseDown(x, y, _ee[0])
+            else:
+                _mouseUp(x, y, _ee[0])
+            
+        if ee == e:
+            return True
+        
 
 def _keyDown(key):
     """Performs a keyboard key press without the release. This will put that


### PR DESCRIPTION
Following two functions were added to **__init__.py** 

**getMouseEvent()** - for getting the next mouse event
**waitForMouseEvent(e)** - waits untill event **e** occurs

Following two functions were added to **_pyautogui_x11.py** which contains the actual code for Unix X11 platforms for above-mentioned functions

**_getMouseEvent()** 
**_waitForMouseEvent(e)** 

