### PR TITLE
Migrate to use Rubicon, rather than PyObjC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 PyAutoGUI
 =========
 
-PyAutoGUI is a  cross-platform GUI automation Python module for human beings. Used to programmatically control the mouse & keyboard.
+PyAutoGUI is a cross-platform GUI automation Python module for human beings.
+Used to programmatically control the mouse & keyboard.
 
 Full documentation available at https://pyautogui.readthedocs.org
 
-Simplified Chinese documentation（简体中文版文档） available at https://muxuezi.github.io/posts/doc-pyautogui.html
+Simplified Chinese documentation（简体中文版文档）available at
+https://muxuezi.github.io/posts/doc-pyautogui.html
 
 Source code available at https://github.com/asweigart/pyautogui
 
@@ -16,17 +18,19 @@ If you are installing PyAutoGUI from PyPI using pip:
 
 Windows has no dependencies. The Win32 extensions do not need to be installed.
 
-OS X needs the pyobjc-core and pyobjc module installed (in that order).
+macOS needs the rubicon-objc module installed.
 
-Linux needs the python3-xlib (or python-xlib for Python 2) module installed.
+Linux needs the python3-xlib module installed.
 
-Pillow needs to be installed, and on Linux you may need to install additional libraries to make sure Pillow's PNG/JPEG works correctly. See:
+Pillow needs to be installed, and on Linux you may need to install additional
+libraries to make sure Pillow's PNG/JPEG works correctly. See:
 
     https://stackoverflow.com/questions/7648200/pip-install-pil-e-tickets-1-no-jpeg-png-support
 
     http://ubuntuforums.org/showthread.php?t=1751455
 
-If you want to do development and contribute to PyAutoGUI, you will need to install these modules from PyPI:
+If you want to do development and contribute to PyAutoGUI, you will need to
+install these modules from PyPI:
 
 * pyscreeze
 * pymsgbox

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,11 @@ setup(
     packages=['pyautogui'],
     test_suite='tests',
     install_requires=['pymsgbox', 'PyTweening>=1.0.1', 'Pillow', 'pyscreeze'],
+    extras_require={
+        ':sys_platform=="linux"': ['python3-Xlib'],
+        ':sys_platform=="darwin"': ['rubicon-objc'],
+    },
+    python_requires='>3.4',
     keywords="gui automation test testing keyboard mouse cursor click press keystroke control",
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This patch migrates PyAutoGUI to use Rubicon, rather than PyObjC. Rubicon is pure Python, and doesn't try to install the entire universe; it requires a *little* more configuration, but it's just as reliable as PyObjC, (in my experience, anyway; Toga uses Rubicon on both iOS and macOS).

Two notes about the patch: 

* There are currently 2 keyboard tests failing - however, they were also failing for me under PyObjC:

```
======================================================================
FAIL: test_press (tests.basicTests.TestKeyboard)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rkm/projects/pyautogui/tests/basicTests.py", line 562, in test_press
    self.assertEqual(response, 'ba')
AssertionError: 'a\x1b[Db' != 'ba'
- b
+ ba


======================================================================
FAIL: test_typewrite_editable (tests.basicTests.TestKeyboard)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rkm/projects/pyautogui/tests/basicTests.py", line 536, in test_typewrite_editable
    self.assertEqual(response, 'c')
AssertionError: 'abc\x1b[D\x1b[D\x1b[D\x1b[3~\x1b[3~' != 'c'
- abc
+ c


----------------------------------------------------------------------
Ran 16 tests in 22.738s

FAILED (failures=2)
```

* It's Python3 only. Rubicon uses a bunch of Py3 features (most notably, type annotations). Besides, PYTHON3 IS THE FUTURE!! :-)
