### PR TITLE
Negative screen coordinates on windows.

### DIFF
--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -56,8 +56,8 @@ INPUT_KEYBOARD = 1
 # which is documented here: http://msdn.microsoft.com/en-us/library/windows/desktop/dd162805(v=vs.85).aspx
 # The POINT structure is used by GetCursorPos().
 class POINT(ctypes.Structure):
-    _fields_ = [("x", ctypes.c_ulong),
-                ("y", ctypes.c_ulong)]
+    _fields_ = [("x", ctypes.c_long),
+                ("y", ctypes.c_long)]
 
 # These ctypes structures are for Win32 INPUT, MOUSEINPUT, KEYBDINPUT, and HARDWAREINPUT structures,
 # used by SendInput and documented here: http://msdn.microsoft.com/en-us/library/windows/desktop/ms646270(v=vs.85).aspx


### PR DESCRIPTION
Allow negative screen coordinates for multi-monitor displays with secondary monitors in the negative direction. Win32 [POINT structure](https://msdn.microsoft.com/en-us/library/windows/desktop/dd162805%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396) is a LONG not ULONG. This causes python the treat negative values as large positive values.

Should be tested/propagated to other OSes.

Should be used in conjunction with removing truncation #192.