### PR TITLE
[WIP] Adds support to automatically install dependencies for Linux/MacOS

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -730,7 +730,7 @@ def dragRel(xOffset=0, yOffset=0, duration=0.0, tween=linear, button='left', pau
         default.
       mouseDownUp (True, False): When true, the mouseUp/Down actions are not perfomed.
         Which allows dragging over multiple (small) actions. 'True' by default.
-        
+
     Returns:
       None
     """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='PyAutoGUI',
-    version=__import__('pyautogui').__version__,
+    version='0.9.36',
     url='https://github.com/asweigart/pyautogui',
     author='Al Sweigart',
     author_email='al@inventwithpython.com',
@@ -12,7 +12,12 @@ setup(
     license='BSD',
     packages=['pyautogui'],
     test_suite='tests',
-    install_requires=['pymsgbox', 'PyTweening>=1.0.1', 'Pillow', 'pyscreeze'],
+    install_requires=(['pymsgbox', 'PyTweening>=1.0.1', 'Pillow', 'pyscreeze']
+                      + ['python3-xlib;sys_platform=="linux"']
+                      + ['python-xlib;sys_platform=="linux2"']
+                      + ['pyobjc-core;sys_platform=="darwin"']
+                      + ['pyobjc;sys_platform=="darwin"']
+                      ),
     keywords="gui automation test testing keyboard mouse cursor click press keystroke control",
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -31,6 +36,7 @@ setup(
         'Programming Language :: Python :: 3.1',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5'
     ],
 )


### PR DESCRIPTION
* Changes the setup.py so that the dependencies that users had
to manually install before, are automatically installed using

`pip install pyautogui`.

This has been tested on `linux` for `python2`, `python3` and it installs
the `python2-xlib` and `python3-xlib` dependencies automatically. Also
this works well on Windows, but Windows doesn't have any dependencies.

Assuming you have `git` and `virtualenv` installed you can test that it
automatically installs the dependencies using the following:

```
mkdir ~/tmp;
cd ~/tmp;
rm -rf env pyautogui;
git clone git@github.com:alphaCTzo7G/pyautogui.git;
virtualenv --python=$(which python3) env;
source env/bin/activate;
pip install -e pyautogui;
pip list;
deactivate
```

* Changes the way that the version of `pyautogui` is evaluated.
Previously, this was being evaluated using a call to
`pyautogui.__init__`. However, that calls `_pyautogui_x11`, which fails
because the dependencies for `linux` are not installed.

Based on some other example `setup.py`, it seems the version number is
set explicitly:

https://gitlab.com/libxc/libxc/blob/master/setup.py
https://gemfury.com/squarecapadmin/python:meinheld/0.6.1/content/setup.py
https://salsa.debian.org/debian/doit/blob/debian/0.28.0-2/setup.py

So, I changed it to a explicity version number.

Please let me know if this works for you.