### PR TITLE
Suggest: remove first dot of tmp filename on MacOS

### DIFF
--- a/pyautogui/screenshotUtil.py
+++ b/pyautogui/screenshotUtil.py
@@ -130,7 +130,7 @@ def _screenshot_win32(imageFilename=None):
 
 def _screenshot_osx(imageFilename=None):
     if imageFilename is None:
-        tmpFilename = '.screenshot%s.png' % (datetime.datetime.now().strftime('%Y-%m%d_%H-%M-%S-%f'))
+        tmpFilename = 'screenshot%s.png' % (datetime.datetime.now().strftime('%Y-%m%d_%H-%M-%S-%f'))
     else:
         tmpFilename = imageFilename
     subprocess.call(['screencapture', '-x', tmpFilename])


### PR DESCRIPTION
Recently, you know, MacOS is updated to Majove.

After updating, screencapture is NOT allowed if this is used to store a filename starting with dot('.').

I think, starting with dot could be removed.

Please, check this suggestion.

If you have a better solution, you're supposed to ignore this.
and I hope you to resolve it.

Thanks in advance.