### PR TITLE
Update screenshot wiki for locateOnScreen

### DIFF
--- a/docs/screenshot.rst
+++ b/docs/screenshot.rst
@@ -74,6 +74,8 @@ The optional `confidence` keyword argument specifies the accuracy with which the
     >>> button7location
     Box(left=1416, top=562, width=50, height=41)
 
+**Note**: You need to have `OpenCV <https://pypi.org/project/opencv-python/>`_ installed for the `confidence` keyword to work.
+
 The `locateCenterOnScreen()` function combines `locateOnScreen()` and `center()`:
 
     >>> import pyautogui


### PR DESCRIPTION
Added information about [OpenCV](https://pypi.org/project/opencv-python/) dependency as discussed in #238, #273, and #297.

Using the `confidence` keyword throws an error if OpenCV is not installed.