### PR TITLE
Fixed Import Error Caused by Changing Name

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -102,12 +102,12 @@ def useImageNotFoundException(value=None):
 if sys.platform == 'win32': # PyGetWindow currently only supports Windows.
     try:
         import pygetwindow
-        from pygetwindow import Window, getFocusedWindow, getWindowsAt, getWindowsWithTitle, getAllWindows, getAllTitles
+        from pygetwindow import Window, getActiveWindow, getWindowsAt, getWindowsWithTitle, getAllWindows, getAllTitles
     except ImportError:
         # If pygetwindow module is not found, those methods will not be available.
         def couldNotImportPyGetWindow():
             raise Exception('PyAutoGUI was unable to import pygetwindow. Please install this module.')
-        Window = getFocusedWindow = getWindowsAt = getWindowsWithTitle = getAllWindows = getAllTitles = couldNotImportPyGetWindow
+        Window = getActiveWindow = getWindowsAt = getWindowsWithTitle = getAllWindows = getAllTitles = couldNotImportPyGetWindow
 
 
 KEY_NAMES = ['\t', '\n', '\r', ' ', '!', '"', '#', '$', '%', '&', "'", '(',


### PR DESCRIPTION
When importing pygetwindow module, error caused by name difference. 
getFocusedWindow -> getActiveWindow.