### PR TITLE
Fix use of pygetwindow.getFocusedWindow

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -102,7 +102,8 @@ def useImageNotFoundException(value=None):
 if sys.platform == 'win32': # PyGetWindow currently only supports Windows.
     try:
         import pygetwindow
-        from pygetwindow import Window, getFocusedWindow, getWindowsAt, getWindowsWithTitle, getAllWindows, getAllTitles
+        from pygetwindow import Window, getWindowsAt, getWindowsWithTitle, getAllWindows, getAllTitles
+        from pygetwindow import getActiveWindow as getFocusedWindow
     except ImportError:
         # If pygetwindow module is not found, those methods will not be available.
         def couldNotImportPyGetWindow():


### PR DESCRIPTION
By using the function `pyautogui.getAllTitles()` I have found an exception while importing the `pygetwindow` module.

Currently `pygetwindow` doesn't have the `getFocusedWindow` function, probably it was replaced by the `getActiveWindow` alias. In this fix I simply imported the `getActiveWindow` function as the `getFocusedWindow` alias (to avoid further changes and API updates).