### PR TITLE
locateCenterOnScreen behaves if image not found

### DIFF
--- a/pyautogui/screenshotUtil.py
+++ b/pyautogui/screenshotUtil.py
@@ -118,7 +118,10 @@ def locateAllOnScreen(image, grayscale=False, limit=None, region=None):
 
 
 def locateCenterOnScreen(image, grayscale=False, region=None):
-    return center(locateOnScreen(image, grayscale, region))
+    imageLocation=locateOnScreen(image, grayscale, region)
+    if imageLocation is not None:
+        return center(imageLocation)
+    return None
 
 
 def _screenshot_win32(imageFilename=None):


### PR DESCRIPTION
locateCenterOnScreen was calling center() regardless of the success of locating the image on the screen.  In cases where this was None, center() would try to address elements in the None and fail.  In this request, I perform a check to see if locate has returned None before calling center, otherwise, None is returned in keeping with the other locate functions.