### PR TITLE
Click states of Mac

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -507,7 +507,7 @@ def click(x=None, y=None, clicks=1, interval=0.0, button=PRIMARY, duration=0.0, 
     _logScreenshot(logScreenshot, 'click', '%s,%s,%s,%s' % (button, clicks, x, y), folder='.')
 
     if sys.platform == 'darwin':
-        platformModule._multiClick(x, y, button, 3)
+        platformModule._multiClick(x, y, button, clicks)
     else:
         for i in range(clicks):
             _failSafeCheck()
@@ -639,7 +639,7 @@ def doubleClick(x=None, y=None, interval=0.0, button=LEFT, duration=0.0, tween=l
         _mouseMoveDrag('move', x, y, 0, 0, duration=0, tween=None)
         x, y = platformModule._position()
         _logScreenshot(logScreenshot, 'click', '%s,2,%s,%s' % (button, x, y), folder='.')
-        platformModule._multiClick(x, y, button, 2)
+        platformModule._multiClick(x, y, button, 2, 2)
     else:
 		# Click for Windows or Linux:
         click(x, y, 2, interval, button, duration, tween, pause, logScreenshot, _pause=False)
@@ -684,7 +684,7 @@ def tripleClick(x=None, y=None, interval=0.0, button=LEFT, duration=0.0, tween=l
         _mouseMoveDrag('move', x, y, 0, 0, duration=0, tween=None)
         x, y = platformModule._position()
         _logScreenshot(logScreenshot, 'click', '%s,3,%s,%s' % (x, y), folder='.')
-        platformModule._multiClick(x, y, button, 3)
+        platformModule._multiClick(x, y, button, 3, 3)
     else:
 		# Click for Windows or Linux:
         click(x, y, 3, interval, button, duration, tween, pause, logScreenshot, _pause=False)

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -387,7 +387,7 @@ def _click(x, y, button):
     else:
         assert False, "button argument not in ('left', 'middle', 'right')"
 
-def _multiClick(x, y, button, num):
+def _multiClick(x, y, button, num, click_state=1):
     btn    = None
     down   = None
     up     = None
@@ -409,11 +409,8 @@ def _multiClick(x, y, button, num):
         return
 
     mouseEvent = Quartz.CGEventCreateMouseEvent(None, down, (x, y), btn)
-    Quartz.CGEventSetIntegerValueField(mouseEvent, Quartz.kCGMouseEventClickState, num)
-    Quartz.CGEventPost(Quartz.kCGHIDEventTap, mouseEvent)
-    Quartz.CGEventSetType(mouseEvent, up)
-    Quartz.CGEventPost(Quartz.kCGHIDEventTap, mouseEvent)
-    for i in range(0, num-1):
+    Quartz.CGEventSetIntegerValueField(mouseEvent, Quartz.kCGMouseEventClickState, click_state)
+    for i in range(0, num):
         Quartz.CGEventSetType(mouseEvent, down)
         Quartz.CGEventPost(Quartz.kCGHIDEventTap, mouseEvent)
         Quartz.CGEventSetType(mouseEvent, up)


### PR DESCRIPTION
Updates how clicking is done in Mac.
Single click type clicks get a click state of 1
Double click type clicks get a click state of 2
Triple Click type clicks get a click state of 3

Simply clicking something 3 times doesn't mean that it's a "triple click". In this case, calling click with a click number of 3 would result in 3 clicks of click state 1.

https://developer.apple.com/documentation/coregraphics/cgeventfield/kcgmouseeventclickstate?language=objc

This fixes #370 and should also address the concerns of #369 