### PR TITLE
Remove unnecessary pyobjc dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     license='BSD',
     packages=['pyautogui'],
     test_suite='tests',
-    install_requires=['pyobjc-core;platform_system=="Darwin"', 'pyobjc;platform_system=="Darwin"',
+    install_requires=['pyobjc-core;platform_system=="Darwin"', 'pyobjc-framework-quartz;platform_system=="Darwin"',
                       'python3-Xlib;platform_system=="Linux" and python_version>="3.0"', 'Xlib;platform_system=="Linux" and python_version<"3.0"',
                       'pymsgbox', 'PyTweening>=1.0.1', 'pyscreeze>=0.1.21', 'pygetwindow>=0.0.5', 'mouseinfo'],
     keywords="gui automation test testing keyboard mouse cursor click press keystroke control",


### PR DESCRIPTION
Currently this project pulls in the full set of pyobjc dependencies. However it only seems to use `pyobjc-framework-quartz`.

Removing the unneeded dependencies speeds up installation, dependency management and reduces install size.