### PR TITLE
Implement the hold() function as a context manager.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,15 +45,15 @@ Examples
     >>> pyautogui.click('button.png') # Find where button.png appears on the screen and click it.
 
     >>> pyautogui.move(400, 0)      # Move the mouse 400 pixels to the right of its current position.
-    >>> pyautogui.doubleClick()    # Double click the mouse.
+    >>> pyautogui.doubleClick()     # Double click the mouse.
     >>> pyautogui.moveTo(500, 500, duration=2, tween=pyautogui.easeInOutQuad)  # Use tweening/easing function to move mouse over 2 seconds.
 
     >>> pyautogui.write('Hello world!', interval=0.25)  # type with quarter-second pause in between each key
     >>> pyautogui.press('esc')     # Press the Esc key. All key names are in pyautogui.KEY_NAMES
 
-    >>> pyautogui.keyDown('shift') # Press the Shift key down and hold it.
-    >>> pyautogui.press(['left', 'left', 'left', 'left']) # Press the left arrow key 4 times.
-    >>> pyautogui.keyUp('shift')   # Let go of the Shift key.
+    >>> with pyautogui.hold('shift'):  # Press the Shift key down and hold it.
+            pyautogui.press(['left', 'left', 'left', 'left'])  # Press the left arrow key 4 times.
+    >>> # Shift key is released automatically.
 
     >>> pyautogui.hotkey('ctrl', 'c') # Press the Ctrl-C hotkey combination.
 

--- a/docs/keyboard.rst
+++ b/docs/keyboard.rst
@@ -55,6 +55,26 @@ Or you can set how many presses `left`:
 
 To add a delay interval in between each press, pass an int or float for the ``interval`` keyword argument.
 
+The hold() Context Manager
+==========================
+
+To make holding a key convenient, the ``hold()`` function can be used as a context manager and passed a string from the ``pyautogui.KEYBOARD_KEYS`` such as ``shift``, ``ctrl``, ``alt``, and this key will be held for the duration of the ``with`` context block. See `KEYBOARD_KEYS`_.
+
+.. code:: python
+
+    >>> with pyautogui.hold('shift'):
+            pyautogui.press(['left', 'left', 'left'])
+
+. . .is equivalent to this code:
+
+.. code:: python
+
+    >>> pyautogui.keyDown('shift')  # hold down the shift key
+    >>> pyautogui.press('left')     # press the left arrow key
+    >>> pyautogui.press('left')     # press the left arrow key
+    >>> pyautogui.press('left')     # press the left arrow key
+    >>> pyautogui.keyUp('shift')    # release the shift key
+
 The hotkey() Function
 =====================
 

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -23,6 +23,7 @@ import platform
 import re
 import functools
 import inspect
+from contextlib import contextmanager
 
 
 class PyAutoGUIException(Exception):
@@ -1596,6 +1597,44 @@ def press(keys, presses=1, interval=0.0, logScreenshot=None, _pause=True):
             platformModule._keyDown(k)
             platformModule._keyUp(k)
         time.sleep(interval)
+
+
+@contextmanager
+@_genericPyAutoGUIChecks
+def hold(keys, logScreenshot=None, _pause=True):
+    """Context manager that performs a keyboard key press down upon entry,
+    followed by a release upon exit.
+
+    Args:
+      key (str, list): The key to be pressed. The valid names are listed in
+      KEYBOARD_KEYS. Can also be a list of such strings.
+      pause (float, optional): How many seconds in the end of function process.
+      None by default, for no pause in the end of function process.
+    Returns:
+      None
+    """
+    if type(keys) == str:
+        if len(keys) > 1:
+            keys = keys.lower()
+        keys = [keys] # If keys is 'enter', convert it to ['enter'].
+    else:
+        lowerKeys = []
+        for s in keys:
+            if len(s) > 1:
+                lowerKeys.append(s.lower())
+            else:
+                lowerKeys.append(s)
+        keys = lowerKeys
+    _logScreenshot(logScreenshot, "press", ",".join(keys), folder=".")
+    for k in keys:
+        failSafeCheck()
+        platformModule._keyDown(k)
+    try:
+        yield
+    finally:
+        for k in keys:
+            failSafeCheck()
+            platformModule._keyUp(k)
 
 
 @_genericPyAutoGUIChecks


### PR DESCRIPTION
While reviewing the documentation, I saw an example for holding down the `shift` key and pressing `left` a few times before releasing the shift key. This PR implements a context manager that holds down the key(s) for the duration of the `with` block before automatically releasing the key(s).

For example, the following:
```
pyautogui.keyDown('shift')  # hold down the shift key
pyautogui.press('left')     # press the left arrow key
pyautogui.press('left')     # press the left arrow key
pyautogui.press('left')     # press the left arrow key
pyautogui.keyUp('shift')    # release the shift key
```

Becomes:
```
with pyautogui.hold('shift'):  # hold down the shift key
    pyautogui.press('left')    # press the left arrow key
    pyautogui.press('left')    # press the left arrow key
    pyautogui.press('left')    # press the left arrow key
```