### PR TITLE
unify python-xlib dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Windows has no dependencies. The Win32 extensions do not need to be installed.
 
 macOS needs the rubicon-objc module installed (in that order).
 
-Linux needs the python3-xlib (or python-xlib for Python 2) module installed.
+Linux needs the python-xlib module installed.
 
 Pillow needs to be installed, and on Linux you may need to install additional libraries to make sure Pillow's PNG/JPEG works correctly. See:
 
@@ -122,4 +122,3 @@ The three major operating systems (Windows, macOS, and Linux) each have differen
 * On macOS, PyAutoGUI uses the `rubicon-objc` module to access the Cocoa API.
 
 * On Linux, PyAutoGUI uses the `Xlib` module to access the X11 or X Window System.
-

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=['pyautogui'],
     test_suite='tests',
     install_requires=['pyobjc-core;platform_system=="Darwin"', 'pyobjc;platform_system=="Darwin"',
-                      'python3-Xlib;platform_system=="Linux" and python_version>="3.0"', 'python-xlib;platform_system=="Linux" and python_version<"3.0"',
+                      'python-xlib;platform_system=="Linux"',
                       'pymsgbox', 'PyTweening>=1.0.1', 'pyscreeze>=0.1.21', 'pygetwindow>=0.0.5', 'mouseinfo'],
     keywords="gui automation test testing keyboard mouse cursor click press keystroke control",
     classifiers=[
@@ -53,4 +53,3 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
 )
-


### PR DESCRIPTION
Thanks for `pyautogui`!

This PR removes reference to `python3-xlib`, leaving only `python-xlib`.

Motivation: it looks like `python3-xlib` development has basically halted, and `python-xlib` is tested all the way [up to python 3.9](https://github.com/python-xlib/python-xlib/blob/master/.travis.yml#L4-L10). Seems simpler to support!
