### PR TITLE
Put pygetwindow behind windows check in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     test_suite='tests',
     install_requires=['pyobjc-core;platform_system=="Darwin"', 'pyobjc;platform_system=="Darwin"',
                       'python3-Xlib;platform_system=="Linux" and python_version>="3.0"', 'python-xlib;platform_system=="Linux" and python_version<"3.0"',
-                      'pymsgbox', 'PyTweening>=1.0.1', 'pyscreeze>=0.1.21', 'pygetwindow>=0.0.5', 'mouseinfo'],
+                      'pygetwindow>=0.0.5;platform_system=="Windows"',
+                      'pymsgbox', 'PyTweening>=1.0.1', 'pyscreeze>=0.1.21', 'mouseinfo'],
     keywords="gui automation test testing keyboard mouse cursor click press keystroke control",
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This puts pygetwindow behind a windows flag... not sure when/if other platforms would be added, but at present pulling in a dependency that immediately fails on import seems rather brutal.