### PR TITLE
Added adjustable system catch up time for macOS

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -558,6 +558,10 @@ MINIMUM_SLEEP = 0.05
 # The number of seconds to pause after EVERY public function call. Useful for debugging:
 PAUSE = 0.1  # Tenth-second pause by default.
 
+# Interface need some catch up time on darwin (macOS) systems. Possible values probably differ based on your system performance.
+# This value affects mouse moveTo, dragTo and key event duration.
+# TODO: Find a dynamic way to let the system catch up instead of blocking with a magic number.
+DARWIN_CATCH_UP_TIME = 0.01
 
 # If the mouse is over a coordinate in FAILSAFE_POINTS and FAILSAFE is True, the FailSafeException is raised.
 # The rest of the points are added to the FAILSAFE_POINTS list at the bottom of this file, after size() has been defined.

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -246,14 +246,14 @@ def _normalKeyEvent(key, upDown):
                         keyboardMapping['shift'], upDown == 'down')
             Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
             # Tiny sleep to let OS X catch up on us pressing shift
-            time.sleep(0.01)
+            time.sleep(pyautogui.DARWIN_CATCH_UP_TIME)
 
         else:
             key_code = keyboardMapping[key]
 
         event = Quartz.CGEventCreateKeyboardEvent(None, key_code, upDown == 'down')
         Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
-        time.sleep(0.01)
+        time.sleep(pyautogui.DARWIN_CATCH_UP_TIME)
 
     # TODO - wait, is the shift key's keyup not done?
     # TODO - get rid of this try-except.
@@ -427,8 +427,8 @@ def _dragTo(x, y, button):
         _sendMouseEvent(Quartz.kCGEventRightMouseDragged , x, y, Quartz.kCGMouseButtonRight)
     else:
         assert False, "button argument not in ('left', 'middle', 'right')"
-    time.sleep(0.01) # needed to allow OS time to catch up.
+    time.sleep(pyautogui.DARWIN_CATCH_UP_TIME) # needed to allow OS time to catch up.
 
 def _moveTo(x, y):
     _sendMouseEvent(Quartz.kCGEventMouseMoved, x, y, 0)
-    time.sleep(0.01) # needed to allow OS time to catch up.
+    time.sleep(pyautogui.DARWIN_CATCH_UP_TIME) # needed to allow OS time to catch up.


### PR DESCRIPTION
pyautogui seemed quite slow in comparison to the other alternatives like pynput and mouse for macOS. After some digging i found out that this catch up time was responsible for the delay in my case.
IMO it makes more sense to make this catch up time adjustable so everyone can find out the sweet spot for their usecases.

The better solution would be to find a way to let Quartz catch up in dynamically.