### PR TITLE
Fixing encoding problems on pyautogui.write( )

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1668,7 +1668,7 @@ def typewrite(message, logScreenshot=None, _pause=True):
 
     _logScreenshot(logScreenshot, "write", message, folder=".")
     
-    if message is list:
+    if type(message) is list:
         for c in message:
             copy(c)
             if platform.system=='Darwin':

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1668,8 +1668,15 @@ def typewrite(message, logScreenshot=None, _pause=True):
 
     _logScreenshot(logScreenshot, "write", message, folder=".")
     
-    for c in message:
-        copy(c)
+    if message is list:
+        for c in message:
+            copy(c)
+            if platform.system=='Darwin':
+                hotkey('command','v') #For MacOS
+            else:
+                hotkey('ctrl','v') #For Windows / Linux
+    else:
+        copy(message)
         if platform.system=='Darwin':
             hotkey('command','v') #For MacOS
         else:

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1651,32 +1651,29 @@ def hold(keys, logScreenshot=None, _pause=True):
 
 
 @_genericPyAutoGUIChecks
-def typewrite(message, interval=0.0, logScreenshot=None, _pause=True):
-    """Performs a keyboard key press down, followed by a release, for each of
-    the characters in message.
+def typewrite(message, logScreenshot=None, _pause=True):
+    """Performs a copy and paste of the message.
 
     The message argument can also be list of strings, in which case any valid
     keyboard name can be used.
 
-    Since this performs a sequence of keyboard presses and does not hold down
-    keys, it cannot be used to perform keyboard shortcuts. Use the hotkey()
-    function for that.
-
     Args:
-      message (str, list): If a string, then the characters to be pressed. If a
-        list, then the key names of the keys to press in order. The valid names
+      message (str, list): If a string, then the characters to be written. If a
+        list, then the key names of the keys to copy and paste in order. The valid names
         are listed in KEYBOARD_KEYS.
-      interval (float, optional): The number of seconds in between each press.
-        0.0 by default, for no pause in between presses.
 
     Returns:
       None
     """
-    interval = float(interval)  # TODO - this should be taken out.
 
     _logScreenshot(logScreenshot, "write", message, folder=".")
-    copy(message)
-    hotkey('ctrl','v')
+    
+    for c in message:
+        copy(c)
+        if platform.system=='Darwin':
+            hotkey('command','v') #For MacOS
+        else:
+            hotkey('ctrl','v') #For Windows / Linux
     copy('') #Clears clipboard
 
 

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -23,6 +23,7 @@ import platform
 import re
 import functools
 from contextlib import contextmanager
+from pyperclip import copy
 
 
 class PyAutoGUIException(Exception):
@@ -1674,12 +1675,8 @@ def typewrite(message, interval=0.0, logScreenshot=None, _pause=True):
     interval = float(interval)  # TODO - this should be taken out.
 
     _logScreenshot(logScreenshot, "write", message, folder=".")
-    for c in message:
-        if len(c) > 1:
-            c = c.lower()
-        press(c, _pause=False)
-        time.sleep(interval)
-        failSafeCheck()
+    copy(message)
+    hotkey('ctrl','v')
 
 
 write = typewrite  # In PyAutoGUI 1.0, write() replaces typewrite().

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1677,6 +1677,7 @@ def typewrite(message, interval=0.0, logScreenshot=None, _pause=True):
     _logScreenshot(logScreenshot, "write", message, folder=".")
     copy(message)
     hotkey('ctrl','v')
+    copy('') #Clears clipboard
 
 
 write = typewrite  # In PyAutoGUI 1.0, write() replaces typewrite().


### PR DESCRIPTION
Since pyperclip is a dependency of pyautogui I used pyperclip.copy( ) and pyautogui.hotkey( ) to make the process of pyautogui.write( ).

This changing will solve enconding bugs such as accentuated letters and non-latin alphabets.

These are two Issues I found about other people reporting the problem:
      #532 "pyautogui.write('@') doesn't work"
      #550 "pyautogui.write() does not support arabic"

Before:
![Before](https://user-images.githubusercontent.com/60260322/116189321-26a2b200-a6ff-11eb-99e6-3dad984c1f40.gif)
After:
![After](https://user-images.githubusercontent.com/60260322/116189337-302c1a00-a6ff-11eb-8228-0cb8402933e6.gif)