### PR TITLE
Fixing encoding problems on pyautogui.write( )

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -16,12 +16,12 @@ from __future__ import absolute_import, division, print_function
 __version__ = "0.9.52"
 
 import sys
-import time
 import datetime
 import os
 import platform
 import re
 import functools
+from time import sleep
 from contextlib import contextmanager
 from pyperclip import copy
 
@@ -559,7 +559,7 @@ else:
 # In seconds. Any duration less than this is rounded to 0.0 to instantly move
 # the mouse.
 MINIMUM_DURATION = 0.1
-# If sleep_amount is less than MINIMUM_DURATION, time.sleep() will be a no-op and the mouse cursor moves there instantly.
+# If sleep_amount is less than MINIMUM_DURATION, sleep() will be a no-op and the mouse cursor moves there instantly.
 # TODO: This value should vary with the platform. http://stackoverflow.com/q/1133857
 MINIMUM_SLEEP = 0.05
 
@@ -641,7 +641,7 @@ def _handlePause(_pause):
     """
     if _pause:
         assert isinstance(PAUSE, int) or isinstance(PAUSE, float)
-        time.sleep(PAUSE)
+        sleep(PAUSE)
 
 
 def _normalizeXYArgs(firstArg, secondArg):
@@ -996,7 +996,7 @@ def click(
             if button in (LEFT, MIDDLE, RIGHT):
                 platformModule._click(x, y, button)
 
-            time.sleep(interval)
+            sleep(interval)
 
 
 @_genericPyAutoGUIChecks
@@ -1488,7 +1488,7 @@ def _mouseMoveDrag(moveOrDrag, x, y, xOffset, yOffset, duration, tween=linear, b
     for tweenX, tweenY in steps:
         if len(steps) > 1:
             # A single step does not require tweening.
-            time.sleep(sleep_amount)
+            sleep(sleep_amount)
 
         tweenX = int(round(tweenX))
         tweenY = int(round(tweenY))
@@ -1609,7 +1609,7 @@ def press(keys, presses=1, interval=0.0, logScreenshot=None, _pause=True):
             failSafeCheck()
             platformModule._keyDown(k)
             platformModule._keyUp(k)
-        time.sleep(interval)
+        sleep(interval)
 
 
 @contextmanager
@@ -1717,12 +1717,12 @@ def hotkey(*args, **kwargs):
         if len(c) > 1:
             c = c.lower()
         platformModule._keyDown(c)
-        time.sleep(interval)
+        sleep(interval)
     for c in reversed(args):
         if len(c) > 1:
             c = c.lower()
         platformModule._keyUp(c)
-        time.sleep(interval)
+        sleep(interval)
 
 
 def failSafeCheck():
@@ -1765,7 +1765,7 @@ def displayMousePosition(xOffset=0, yOffset=0):
             else:
                 # If this isn't a terminal (i.e. IDLE) then we can only append more text. Print a newline instead and pause a second (so we don't send too much output).
                 sys.stdout.write("\n")
-                time.sleep(1)
+                sleep(1)
             sys.stdout.flush()
     except KeyboardInterrupt:
         sys.stdout.write("\n")
@@ -1799,13 +1799,13 @@ def _snapshot(tag, folder=None, region=None, radius=None):
 
 
 def sleep(seconds):
-    time.sleep(seconds)
+    sleep(seconds)
 
 
 def countdown(seconds):
     for i in range(seconds, 0, -1):
         print(str(i), end=" ", flush=True)
-        time.sleep(1)
+        sleep(1)
     print()
 
 

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1652,22 +1652,13 @@ def hold(keys, logScreenshot=None, _pause=True):
 
 @_genericPyAutoGUIChecks
 def typewrite(message, logScreenshot=None, _pause=True):
-    """Performs a keyboard key press down, followed by a release, for each of
-    the characters in message.
+    """Performs a copy and paste of the string in message.
 
-    The message argument can also be list of strings, in which case any valid
-    keyboard name can be used.
-
-    Since this performs a sequence of keyboard presses and does not hold down
-    keys, it cannot be used to perform keyboard shortcuts. Use the hotkey()
-    function for that.
+    The message argument can also be list of strings.
 
     Args:
-      message (str, list): If a string, then the characters to be pressed. If a
-        list, then the key names of the keys to press in order. The valid names
-        are listed in KEYBOARD_KEYS.
-      interval (float, optional): The number of seconds in between each press.
-        0.0 by default, for no pause in between presses.
+      message (str, list): If a string, then the message to be copy and pasted. If a
+        list, then the strings to be pasted in order.
 
     Returns:
       None

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -23,6 +23,7 @@ import platform
 import re
 import functools
 from contextlib import contextmanager
+from pyperclip import copy
 
 
 class PyAutoGUIException(Exception):

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -22,8 +22,8 @@ import os
 import platform
 import re
 import functools
+import pyperclip
 from contextlib import contextmanager
-from pyperclip import copy
 
 
 class PyAutoGUIException(Exception):
@@ -1676,18 +1676,18 @@ def typewrite(message, logScreenshot=None, _pause=True):
     _logScreenshot(logScreenshot, "write", message, folder=".")
     if type(message) is list:
         for c in message:
-            copy(c)
+            pyperclip.copy(c)
             if sys.platform=='darwin':
                 hotkey('command','v') #For MacOS
             else:
                 hotkey('ctrl','v') #For Windows / Linux
     else:
-        copy(message)
+        pyperclip.copy(message)
         if sys.platform=='darwin':
             hotkey('command','v') #For MacOS
         else:
             hotkey('ctrl','v') #For Windows / Linux
-    copy('') #Clears clipboard
+    pyperclip.copy('') #Clears clipboard
 
 
 write = typewrite  # In PyAutoGUI 1.0, write() replaces typewrite().

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -16,12 +16,12 @@ from __future__ import absolute_import, division, print_function
 __version__ = "0.9.52"
 
 import sys
+import time
 import datetime
 import os
 import platform
 import re
 import functools
-from time import sleep
 from contextlib import contextmanager
 from pyperclip import copy
 
@@ -559,7 +559,7 @@ else:
 # In seconds. Any duration less than this is rounded to 0.0 to instantly move
 # the mouse.
 MINIMUM_DURATION = 0.1
-# If sleep_amount is less than MINIMUM_DURATION, sleep() will be a no-op and the mouse cursor moves there instantly.
+# If sleep_amount is less than MINIMUM_DURATION, time.sleep() will be a no-op and the mouse cursor moves there instantly.
 # TODO: This value should vary with the platform. http://stackoverflow.com/q/1133857
 MINIMUM_SLEEP = 0.05
 
@@ -641,7 +641,7 @@ def _handlePause(_pause):
     """
     if _pause:
         assert isinstance(PAUSE, int) or isinstance(PAUSE, float)
-        sleep(PAUSE)
+        time.sleep(PAUSE)
 
 
 def _normalizeXYArgs(firstArg, secondArg):
@@ -996,7 +996,7 @@ def click(
             if button in (LEFT, MIDDLE, RIGHT):
                 platformModule._click(x, y, button)
 
-            sleep(interval)
+            time.sleep(interval)
 
 
 @_genericPyAutoGUIChecks
@@ -1488,7 +1488,7 @@ def _mouseMoveDrag(moveOrDrag, x, y, xOffset, yOffset, duration, tween=linear, b
     for tweenX, tweenY in steps:
         if len(steps) > 1:
             # A single step does not require tweening.
-            sleep(sleep_amount)
+            time.sleep(sleep_amount)
 
         tweenX = int(round(tweenX))
         tweenY = int(round(tweenY))
@@ -1609,7 +1609,7 @@ def press(keys, presses=1, interval=0.0, logScreenshot=None, _pause=True):
             failSafeCheck()
             platformModule._keyDown(k)
             platformModule._keyUp(k)
-        sleep(interval)
+        time.sleep(interval)
 
 
 @contextmanager
@@ -1717,12 +1717,12 @@ def hotkey(*args, **kwargs):
         if len(c) > 1:
             c = c.lower()
         platformModule._keyDown(c)
-        sleep(interval)
+        time.sleep(interval)
     for c in reversed(args):
         if len(c) > 1:
             c = c.lower()
         platformModule._keyUp(c)
-        sleep(interval)
+        time.sleep(interval)
 
 
 def failSafeCheck():
@@ -1765,7 +1765,7 @@ def displayMousePosition(xOffset=0, yOffset=0):
             else:
                 # If this isn't a terminal (i.e. IDLE) then we can only append more text. Print a newline instead and pause a second (so we don't send too much output).
                 sys.stdout.write("\n")
-                sleep(1)
+                time.sleep(1)
             sys.stdout.flush()
     except KeyboardInterrupt:
         sys.stdout.write("\n")
@@ -1799,13 +1799,13 @@ def _snapshot(tag, folder=None, region=None, radius=None):
 
 
 def sleep(seconds):
-    sleep(seconds)
+    time.sleep(seconds)
 
 
 def countdown(seconds):
     for i in range(seconds, 0, -1):
         print(str(i), end=" ", flush=True)
-        sleep(1)
+        time.sleep(1)
     print()
 
 

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1677,13 +1677,13 @@ def typewrite(message, logScreenshot=None, _pause=True):
     if type(message) is list:
         for c in message:
             copy(c)
-            if platform.system=='Darwin':
+            if sys.platform=='darwin':
                 hotkey('command','v') #For MacOS
             else:
                 hotkey('ctrl','v') #For Windows / Linux
     else:
         copy(message)
-        if platform.system=='Darwin':
+        if sys.platform=='darwin':
             hotkey('command','v') #For MacOS
         else:
             hotkey('ctrl','v') #For Windows / Linux

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1674,12 +1674,20 @@ def typewrite(message, interval=0.0, logScreenshot=None, _pause=True):
     interval = float(interval)  # TODO - this should be taken out.
 
     _logScreenshot(logScreenshot, "write", message, folder=".")
-    for c in message:
-        if len(c) > 1:
-            c = c.lower()
-        press(c, _pause=False)
-        time.sleep(interval)
-        failSafeCheck()
+    if type(message) is list:
+        for c in message:
+            copy(c)
+            if platform.system=='Darwin':
+                hotkey('command','v') #For MacOS
+            else:
+                hotkey('ctrl','v') #For Windows / Linux
+    else:
+        copy(message)
+        if platform.system=='Darwin':
+            hotkey('command','v') #For MacOS
+        else:
+            hotkey('ctrl','v') #For Windows / Linux
+    copy('') #Clears clipboard
 
 
 write = typewrite  # In PyAutoGUI 1.0, write() replaces typewrite().

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1650,7 +1650,7 @@ def hold(keys, logScreenshot=None, _pause=True):
 
 
 @_genericPyAutoGUIChecks
-def typewrite(message, interval=0.0, logScreenshot=None, _pause=True):
+def typewrite(message, logScreenshot=None, _pause=True):
     """Performs a keyboard key press down, followed by a release, for each of
     the characters in message.
 
@@ -1671,7 +1671,6 @@ def typewrite(message, interval=0.0, logScreenshot=None, _pause=True):
     Returns:
       None
     """
-    interval = float(interval)  # TODO - this should be taken out.
 
     _logScreenshot(logScreenshot, "write", message, folder=".")
     if type(message) is list:


### PR DESCRIPTION
Since pyperclip is a dependency of pyautogui I used pyperclip.copy( ) and pyautogui.hotkey( ) to make the process of pyautogui.write( ).

This changing will solve enconding bugs such as accentuated letters and non-latin alphabets.

These are two Issues I found about other people reporting the problem:
#532 "pyautogui.write('@') doesn't work"
#550 "pyautogui.write() does not support arabic"

Before:
![Before](https://user-images.githubusercontent.com/60260322/116460506-830beb80-a83d-11eb-9f25-8477de15560a.gif)
After
![After](https://user-images.githubusercontent.com/60260322/116460517-843d1880-a83d-11eb-9d93-dbb37c9bac22.gif)