### PR TITLE
Fix issue with '<' in Linux

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -533,6 +533,10 @@ def isShiftCharacter(character):
     uppercase letters or the symbols on the keyboard's number row.
     """
     # NOTE TODO - This will be different for non-qwerty keyboards.
+
+    if platform.system() == "Linux":
+        return character.isupper() or character in set('~!@#$%^&*()_+{}|:">?')
+
     return character.isupper() or character in set('~!@#$%^&*()_+{}|:"<>?')
 
 


### PR DESCRIPTION
In Linux `pyautogui.write('<')` types `>` instead (#580 ). In windows it works fine. 
After some digging, I found by removing '<' from `isShiftCharacter` fixed the issue. 

I don't know if there is a similar problem in macOS, so I have only changed it for Linux.