### PR TITLE
Fix Issue #559

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -654,7 +654,13 @@ def _normalizeXYArgs(firstArg, secondArg):
     """
     if firstArg is None and secondArg is None:
         return position()
-
+    
+    elif firstArg is None and secondArg is not None:
+        return Point(int(position()[0]), int(secondArg))
+    
+    elif secondArg is None and firstArg is not None:
+        return Point(int(firstArg), int(position()[1]))
+    
     elif isinstance(firstArg, str):
         # If x is a string, we assume it's an image filename to locate on the screen:
         try:


### PR DESCRIPTION
Fixes issue #559 where calling moveTo() causes an error when passed singular None containing x-y coordinates despite it being doable according to the docs as mentioned by the author of the issue. Only the case where double None containing x-y coordinates was handled. The other two cases where either only x or only y is None can be easily handled similarly by replacing the None with the current x or y position by calling position() and indexing the tuple accordingly.