### PR TITLE
Palliative correction of function locateOnWindow

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -215,9 +215,22 @@ try:
     locateOnScreen.__doc__ = pyscreeze.locateOnScreen.__doc__
 
     @raisePyAutoGUIImageNotFoundException
-    def locateOnWindow(*args, **kwargs):
-        return pyscreeze.locateOnWindow(*args, **kwargs)
+    def locateOnWindow(image, title):
+        matchingWindows = getWindowsWithTitle(title)
+        if len(matchingWindows) == 0:
+            raise PyScreezeException('Could not find a window with %s in the title' % (title))
+        elif len(matchingWindows) > 1:
+            raise PyScreezeException('Found multiple windows with %s in the title: %s' % (title, [str(win) for win in matchingWindows]))
 
+        win = matchingWindows[0]
+        win.activate()   
+
+        window_handle = FindWindow(None, title)
+        region = GetWindowRect(window_handle)
+
+        return pyscreeze.locateOnScreen(image, region)
+    
+    
     locateOnWindow.__doc__ = pyscreeze.locateOnWindow.__doc__
 
 


### PR DESCRIPTION
# What does this PR do?

Fix the ```pyautogui.locateOnWindow()``` 

# Why was it initiated? 

When I tried to use this function, it returned a ValueError

```Traceback (most recent call last):                                                                                      
  File "C:\Users\Administrator\Desktop\Teste\localize.py", line 21, in <module>                                         
    position = pyautogui.locateOnWindow('connect-wallet.png', title=title)                                              
  File "C:\Users\Administrator\Desktop\Teste\venv\lib\site-packages\pyautogui\__init__.py", line 175, in wrapper        
    return wrappedFunction(*args, **kwargs)                                                                             
  File "C:\Users\Administrator\Desktop\Teste\venv\lib\site-packages\pyautogui\__init__.py", line 219, in locateOnWindow 
    return pyscreeze.locateOnWindow(*args, **kwargs)                                                                    
  File "C:\Users\Administrator\Desktop\Teste\venv\lib\site-packages\pyscreeze\__init__.py", line 434, in locateOnWindow 
    return locateOnScreen(image, region=(win.left, win.top, win.width, win.height), **kwargs)                           
  File "C:\Users\Administrator\Desktop\Teste\venv\lib\site-packages\pyscreeze\__init__.py", line 373, in locateOnScreen 
    retVal = locate(image, screenshotIm, **kwargs)                                                                      
  File "C:\Users\Administrator\Desktop\Teste\venv\lib\site-packages\pyscreeze\__init__.py", line 353, in locate         
    points = tuple(locateAll(needleImage, haystackImage, **kwargs))                                                     
  File "C:\Users\Administrator\Desktop\Teste\venv\lib\site-packages\pyscreeze\__init__.py", line 219, in _locateAll_opencv                                                                                                                      
    raise ValueError('needle dimension(s) exceed the haystack image or region dimensions')                              
ValueError: needle dimension(s) exceed the haystack image or region dimensions   ```

