### PR TITLE
Update for __init__.py Move() NoneType Error

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -704,6 +704,8 @@ def _normalizeXYArgs(firstArg, secondArg):
                 )
             )
     else:
+        firstArg = 0 if firstArg is None else firstArg
+        secondArg = 0 if secondArg is None else secondArg
         return Point(int(firstArg), int(secondArg))  # firstArg and secondArg are just x and y number values
 
 


### PR DESCRIPTION
Hi all, This is a quick fix for #684.  I modified `_normalizeXYArgs()` to give return results a default Zero if `NoneType`, since we cannot use `int(None)`.  
This stops the errors and behaves as my understanding of the [documentation](https://github.com/asweigart/pyautogui/blob/master/README.md#keyboard-and-mouse-control).  

ie:
```python
import pyautogui
pyautogui.move(None, 10)  
# Move mouse 10 pixels down, that is, 
# move the mouse relative to its current position.
```

@asweigart I am not sure if this is what is desired, but tested and works.  Please update as needed.

Python: 3.9.5
PyAutoGUI: 0.9.53
OS: MacOS 12.3.1 Monterey

This is in addition to #559 #592 that have already been merged as similar fixes.


Error Fixed was : 
```python
>>> import pyautogui
>>> pyautogui.move(None, 10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pyautogui/__init__.py", line 598, in wrapper
    returnVal = wrappedFunction(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pyautogui/__init__.py", line 1310, in moveRel
    xOffset, yOffset = _normalizeXYArgs(xOffset, yOffset)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pyautogui/__init__.py", line 701, in _normalizeXYArgs
    return Point(int(firstArg), int(secondArg))  # firstArg and secondArg are just x and y number values
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

Changes the behaviour to conform to the documentation & as follows

```python
import pyautogui
pyautogui.position()
pyautogui.move(100, None)   # Moves Right horizontally from current position
pyautogui.position()
pyautogui.move(None, 100)  # Moves Down vertically from current position
pyautogui.position()
pyautogui.move(-100, None)   # Moves Left horizontally from current position
pyautogui.position()
pyautogui.move(None, -100)  # Moves Up vertically from current position
pyautogui.position()

pyautogui.position()
pyautogui.move(None, None)   
# *** This has a problem, going to address in a separate PR.  
# As the current behaviour double x, y coordinates. instead of doing nothing, but, that would be my, expectation.
pyautogui.position()
# Point(x=386, y=281)
# Point(x=772, y=562)
```