### PR TITLE
Set offset to zero if null for movRel(None,None)

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1313,6 +1313,8 @@ def moveRel(xOffset=None, yOffset=None, duration=0.0, tween=linear, logScreensho
     Returns:
       None
     """
+    xOffset = 0 if xOffset is None else xOffset
+    yOffset = 0 if yOffset is None else yOffset
     xOffset, yOffset = _normalizeXYArgs(xOffset, yOffset)
 
     _logScreenshot(logScreenshot, "moveRel", "%s,%s" % (xOffset, yOffset), folder=".")


### PR DESCRIPTION
When calling `_normalizeXYArgs(xOffset, yOffset)`  if None is passed for both values the offset is returned with position(x,y) of where the mouse currently is.

```python
# line 655
    if firstArg is None and secondArg is None:
        return position()
```

This was updated for dragRel() & mouseMoveDrag() & displayMousePosition() but not for movRel().

Therefore artificially moving the mouse dramatically off the screen depending on location of starting position.

This fixes the issue.