### PR TITLE
proposition concering shift typing on mac

### DIFF
--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -244,9 +244,12 @@ def _normalKeyEvent(key, upDown):
 
             event = Quartz.CGEventCreateKeyboardEvent(None,
                         keyboardMapping['shift'], upDown == 'down')
-            Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
-            # Tiny sleep to let OS X catch up on us pressing shift
-            time.sleep(pyautogui.DARWIN_CATCH_UP_TIME)
+            # 278Mt's comment: It is better to type with shift key with CGEventSetFlags() function.
+            # reference is:
+            # [here](https://stackoverflow.com/questions/55120977/how-press-shift-command-3-simultaneously-programmatically)
+            # and [here](https://code-examples.net/en/q/1ea43e),
+            # NOT [here](https://developer.apple.com/documentation/coregraphics/1456564-cgeventcreatekeyboardevent)
+            Quartz.CGEventSetFlags(event, Quartz.kCGEventFlagMaskShift)
 
         else:
             key_code = keyboardMapping[key]


### PR DESCRIPTION
I propose to rewrite such my code concerning shift typing on mac.

```py
def _normalKeyEvent(key, upDown):
    assert upDown in ('up', 'down'), "upDown argument must be 'up' or 'down'"

    try:
        if pyautogui.isShiftCharacter(key):
            key_code = keyboardMapping[key.lower()]

            event = Quartz.CGEventCreateKeyboardEvent(None,
                        keyboardMapping['shift'], upDown == 'down')
            # 278Mt's comment: It is better to type with shift key with CGEventSetFlags() function.
            # reference is:
            # [here](https://stackoverflow.com/questions/55120977/how-press-shift-command-3-simultaneously-programmatically)
            # and [here](https://code-examples.net/en/q/1ea43e),
            # NOT [here](https://developer.apple.com/documentation/coregraphics/1456564-cgeventcreatekeyboardevent)
            Quartz.CGEventSetFlags(event, Quartz.kCGEventFlagMaskShift)

        else:
            key_code = keyboardMapping[key]

        event = Quartz.CGEventCreateKeyboardEvent(None, key_code, upDown == 'down')
        Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
        time.sleep(pyautogui.DARWIN_CATCH_UP_TIME)

    # TODO - wait, is the shift key's keyup not done?
    # TODO - get rid of this try-except.

    except KeyError:
        raise RuntimeError("Key %s not implemented." % (key))
```

I've translated Swift into Python on [here](https://stackoverflow.com/questions/55120977/how-press-shift-command-3-simultaneously-programmatically) and [here](https://code-examples.net/en/q/1ea43e), NOT [here](https://developer.apple.com/documentation/coregraphics/1456564-cgeventcreatekeyboardevent)