### PR TITLE
Fixes #698

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1165,7 +1165,7 @@ def tripleClick(x=None, y=None, interval=0.0, button=LEFT, duration=0.0, tween=l
         x, y = _normalizeXYArgs(x, y)
         _mouseMoveDrag("move", x, y, 0, 0, duration=0, tween=None)
         x, y = platformModule._position()
-        _logScreenshot(logScreenshot, "click", "%s,3,%s,%s" % (x, y), folder=".")
+        _logScreenshot(logScreenshot, "click", "%s,3,%s,%s" % (button, x, y), folder=".")
         platformModule._multiClick(x, y, button, 3)
     else:
         # Click for Windows or Linux:


### PR DESCRIPTION
Fixes issue #698 which leads to a crash on MacOS whenever tripleClick was called due to missing an argument in string formatting.