### PR TITLE
pyautogui.cposition() xy & rgb color returned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 *.egg-info/
 
 Pipfile.lock
+.DS_Store

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,13 @@ Examples
     >>> currentMouseX, currentMouseY
     (1314, 345)
 
+    >>> ((currentMouseX, currentMouseY), (red, green, blue, alpha)) = pyautogui.cposition() # Get the XY position of the mouse with the color RGBA.
+    >>> currentMouseX, currentMouseY
+    (1314, 345)
+    >>> red, green, blue, alpha
+    (45, 163, 52, 255)  # osx
+    (45, 163, 52, None) # win
+
     >>> pyautogui.moveTo(100, 150) # Move the mouse to XY coordinates.
 
     >>> pyautogui.click()          # Click the mouse.

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -778,6 +778,34 @@ def position(x=None, y=None):
     return Point(posx, posy)
 
 
+def cposition(x=None, y=None):
+    """
+    Same as position, but returns the color value as well.
+    Returns the current xy coordinates of the mouse cursor as a two-integer tuple.
+    and the current RGB with Opacity coordinates of the mouse cursor as a four-integer tuple.
+
+    Args:
+      x (int, None, optional) - If not None, this argument overrides the x in
+        the return value.
+      y (int, None, optional) - If not None, this argument overrides the y in
+        the return value.
+
+    Returns:
+      (x, y), (r, g, b, alpha) tuple of the current xy coordinates of the mouse cursor.
+
+    NOTE: The position() function doesn't check for failsafe.
+    """
+    posx, posy = platformModule._position()
+    posx = int(posx)
+    posy = int(posy)
+    if x is not None:  # If set, the x parameter overrides the return value.
+        posx = int(x)
+    if y is not None:  # If set, the y parameter overrides the return value.
+        posy = int(y)
+    r, g, b, alpha = pyscreeze.screenshot().getpixel((posx, posy))
+    return Point(posx, posy), (r, g, b, alpha)
+
+
 def size():
     """Returns the width and height of the screen as a two-integer tuple.
 


### PR DESCRIPTION
Returns position with RGB & Alpha as two tuples.

I figured it would be a nice to have.  Currently Tested only on Mac.

@asweigart let me know if you want me to make any adjustments to this branch.

```python
import pyautogui

((currentMouseX, currentMouseY), (red, green, blue, alpha)) = pyautogui.cposition() 
# Get the current XY position of the mouse with the color RGBA.

((currentMouseX, currentMouseY), (red, green, blue, alpha)) = pyautogui.cposition(1314, 345) 
# Or Get a specific XY position of the mouse with the color RGBA.

currentMouseX, currentMouseY
#    1314, 345
red, green, blue, alpha
#    45, 163, 52, 255  # osx
#    45, 163, 52, None # win
```