### PR TITLE
Made press() work with cyrillic

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -216,9 +216,9 @@ try:
 
     @raisePyAutoGUIImageNotFoundException
     def locateOnWindow(*args, **kwargs):
-        return pyscreeze.locateOnWindow(*args, **kwargs)
+        return pyscreeze.locateOnScreen(*args, **kwargs)
 
-    locateOnWindow.__doc__ = pyscreeze.locateOnWindow.__doc__
+    locateOnWindow.__doc__ = pyscreeze.locateOnScreen.__doc__
 
 
 except ImportError:
@@ -525,7 +525,7 @@ SECONDARY = "secondary"
 # NOTE: Eventually, I'd like to come up with a better system than this. For now, this seems like it works.
 QWERTY = r"""`1234567890-=qwertyuiop[]\asdfghjkl;'zxcvbnm,./~!@#$%^&*()_+QWERTYUIOP{}|ASDFGHJKL:"ZXCVBNM<>?"""
 QWERTZ = r"""=1234567890/0qwertzuiop89-asdfghjkl,\yxcvbnm,.7+!@#$%^&*()?)QWERTZUIOP*(_ASDFGHJKL<|YXCVBNM<>&"""
-
+cyrillic = r"""=1234567890/0йцукеягшщз89-фывапролдбёнчсмитьбю7+!"№%:,.;()?)ЙЦУКЕЯГШЩЗ;(_ФЫВАПРОЛДБЁНЧСМИТЬБЮ."""
 
 def isShiftCharacter(character):
     """
@@ -1612,8 +1612,15 @@ def press(keys, presses=1, interval=0.0, logScreenshot=None, _pause=True):
     for i in range(presses):
         for k in keys:
             failSafeCheck()
-            platformModule._keyDown(k)
-            platformModule._keyUp(k)
+            if k in QWERTY:
+                platformModule._keyDown(k)
+                platformModule._keyUp(k)
+            elif k in cyrillic:
+
+                k = QWERTY[cyrillic.index(k)]
+                platformModule._keyDown(k)
+                platformModule._keyUp(k)
+
         time.sleep(interval)
 
 
@@ -1677,6 +1684,7 @@ def typewrite(message, interval=0.0, logScreenshot=None, _pause=True):
     Returns:
       None
     """
+
     interval = float(interval)  # TODO - this should be taken out.
 
     _logScreenshot(logScreenshot, "write", message, folder=".")

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -10,7 +10,7 @@ import AppKit
 import pyautogui
 from pyautogui import LEFT, MIDDLE, RIGHT
 
-if sys.platform !=  'darwin':
+if sys.platform != 'darwin':
     raise Exception('The pyautogui_osx module should only be loaded on an OS X system.')
 
 


### PR DESCRIPTION
You couldn't ask pyautogui to write cyrillic, but there was a way around: just write cyrillic symbols with QWERTY selected, and `write()` that gibberish. That's ugly, so I added cyrillic, the same length as that QWERTY thing, and now it checks if the symbol is in cyrillic every `press()` call. If it is, it just gets its index and presses a QWERTY symbol with that index. If russian keyboard is selected - it works just fine.

Also changed that `pyscreeze.locateOnWindow.` to `pyscreeze.locateOnScreen` cuz it kept throwing an error.