### PR TITLE
Fixing a typo in screenshot.rst

### DIFF
--- a/docs/screenshot.rst
+++ b/docs/screenshot.rst
@@ -92,7 +92,7 @@ There are several "locate" functions. They all start looking at the top-left cor
 The "locate all" functions can be used in for loops or passed to `list()`:
 
     >>> import pyautogui
-    >>> for pos in pyautogui.locateAllOnScreen('someButton.png')
+    >>> for pos in pyautogui.locateAllOnScreen('someButton.png'):
     ...   print(pos)
     ...
     (1101, 252, 50, 50)


### PR DESCRIPTION
While executing existing code from docs, I suffered a syntax error. I believe that in line 95 after declaring for loop there should be a colon at the end of the line.