### PR TITLE
Checking for swapped mouse controls on Windows

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -864,7 +864,7 @@ def _normalizeButton(button):
 
     # TODO - Check if the primary/secondary mouse buttons have been swapped:
     if button in (PRIMARY, SECONDARY):
-        swapped = False  # TODO - Add the operating system-specific code to detect mouse swap later.
+        swapped = platformModule.swapped()  # TODO - Add the operating system-specific code to detect mouse swap later.
         if swapped:
             if button == PRIMARY:
                 return RIGHT

--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -331,6 +331,11 @@ def _keyUp(key):
         if apply_mod:
             ctypes.windll.user32.keybd_event(vk_mod, 0, KEYEVENTF_KEYUP, 0) #
 
+def swapped():
+    sm_swapbutton = 23
+    user32 = ctypes.windll.user32
+    _swapped = user32.GetSystemMetrics(sm_swapbutton)
+    return _swapped != 0
 
 def _position():
     """Returns the current xy coordinates of the mouse cursor as a two-integer


### PR DESCRIPTION
Currently only implemented on the windows platform module. The swapped function is called inside the _normalizeButton function in __init__. Uses the ctypes library in order to check whether the primary or secondary mouse is swapped due to left-handed preference. Functions returns true if mouse is swapped. 

Working on Mac and Linux implementation, soon to be.