### PR TITLE
following suggestion to fix multiclick on darwin (fixes #672)

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -991,10 +991,9 @@ def click(
     _logScreenshot(logScreenshot, "click", "%s,%s,%s,%s" % (button, clicks, x, y), folder=".")
 
     if sys.platform == 'darwin':
-        for i in range(clicks):
-            failSafeCheck()
-            if button in (LEFT, MIDDLE, RIGHT):
-                platformModule._multiClick(x, y, button, 1, interval)
+        failSafeCheck()
+        if button in (LEFT, MIDDLE, RIGHT):
+            platformModule._multiClick(x, y, button, clicks, interval)
     else:
         for i in range(clicks):
             failSafeCheck()

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -408,10 +408,20 @@ def _multiClick(x, y, button, num, interval=0.0):
         assert False, "button argument not in ('left', 'middle', 'right')"
         return
 
-    for i in range(num):
-        _click(x, y, button)
-        time.sleep(interval)
+    # create event, initial direction is down
+    multiClickEvent = Quartz.CGEventCreateMouseEvent(None, down, (x,y), btn)
+    # set number of clicks
+    Quartz.CGEventSetIntegerValueField(multiClickEvent, Quartz.kCGMouseEventClickState, num)
 
+    # per click we need to post 2 events (down, up)
+    for i in range(2*num):
+        # post previous event
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, multiClickEvent)
+        # set type for next event
+        if i % 2 == 0:
+            Quartz.CGEventSetType(multiClickEvent, up)
+        else:
+            Quartz.CGEventSetType(multiClickEvent, down)
 
 def _sendMouseEvent(ev, x, y, button):
     mouseEvent = Quartz.CGEventCreateMouseEvent(None, ev, (x, y), button)


### PR DESCRIPTION
I'm not an expert in macOS programming, but following this issue https://github.com/asweigart/pyautogui/issues/672 and the referred stackoverflow discussion (https://stackoverflow.com/questions/1483657/performing-a-double-click-using-cgeventcreatemouseevent), I altered the code so that on my macOS (Ventura 13.3.1) multiclicks and single clicks are working again.