### PR TITLE
Small fix to comment in documentation

### DIFF
--- a/docs/mouse.rst
+++ b/docs/mouse.rst
@@ -121,7 +121,7 @@ PyAutoGUI's ``dragTo()`` and ``drag()`` functions have similar parameters as the
 
     >>> pyautogui.dragTo(100, 200, button='left')     # drag mouse to X of 100, Y of 200 while holding down left mouse button
     >>> pyautogui.dragTo(300, 400, 2, button='left')  # drag mouse to X of 300, Y of 400 over 2 seconds while holding down left mouse button
-    >>> pyautogui.drag(30, 0, 2, button='right')   # drag the mouse left 30 pixels over 2 seconds while holding down the right mouse button
+    >>> pyautogui.drag(30, 0, 2, button='right')   # drag the mouse right 30 pixels over 2 seconds while holding down the right mouse button
 
 
 Tween / Easing Functions


### PR DESCRIPTION
Fixed comment that was meant to say right instead of left.