### PR TITLE
Enable use on BSD distros.

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -540,7 +540,7 @@ elif sys.platform == "darwin":
     from . import _pyautogui_osx as platformModule
 elif sys.platform == "win32":
     from . import _pyautogui_win as platformModule
-elif platform.system() == "Linux":
+elif platform.system() == "Linux" or "BSD" in platform.system():
     from . import _pyautogui_x11 as platformModule
 else:
     raise NotImplementedError("Your platform (%s) is not supported by PyAutoGUI." % (platform.system()))


### PR DESCRIPTION
I only tested this on FreeBSD, but I added a broad match for any BSD. If you'd prefer a specific match for FreeBSD, just let me know. It seems safe enough to allow any BSD to use it, though.