### PR TITLE
added an exception error when using the wrong variable type in _moveto function

### DIFF
--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -444,5 +444,8 @@ def _dragTo(x, y, button):
     time.sleep(pyautogui.DARWIN_CATCH_UP_TIME) # needed to allow OS time to catch up.
 
 def _moveTo(x, y):
+    if (type(x) != int or type(y) != int):
+        raise Exception('The coordinates variable type must be int ')
     _sendMouseEvent(Quartz.kCGEventMouseMoved, x, y, 0)
     time.sleep(pyautogui.DARWIN_CATCH_UP_TIME) # needed to allow OS time to catch up.
+

--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -366,6 +366,8 @@ def _moveTo(x, y):
     Returns:
       None
     """
+    if(type(x) != int or type(y) != int):
+        raise Exception('The coordinates variable type must be int ')
     ctypes.windll.user32.SetCursorPos(x, y)
     # This was a possible solution to issue #314 https://github.com/asweigart/pyautogui/issues/314
     # but I'd like to hang on to SetCursorPos because mouse_event() has been superseded.
@@ -570,4 +572,5 @@ def _vscroll(clicks, x, y):
       None
     """
     return _scroll(clicks, x, y)
+
 

--- a/pyautogui/_pyautogui_x11.py
+++ b/pyautogui/_pyautogui_x11.py
@@ -98,6 +98,8 @@ def _mouse_is_swapped():
 
 
 def _moveTo(x, y):
+    if (type(x) != int or type(y) != int):
+        raise Exception('The coordinates variable type must be int ')
     fake_input(_display, X.MotionNotify, x=x, y=y)
     _display.sync()
 


### PR DESCRIPTION
> This error was added to solve the following issue [https://github.com/asweigart/pyautogui/issues/789](url)


**_pyautogui_win.py**

![image](https://github.com/asweigart/pyautogui/assets/72312794/9838e582-4c53-4d7a-ab04-0e66afe05c31)

**_pyautogui_x11.py**

![image](https://github.com/asweigart/pyautogui/assets/72312794/01b448d1-f051-4aea-b96d-d79343c12f56)

**_pyautogui_osx.py**

![image](https://github.com/asweigart/pyautogui/assets/72312794/a200b21f-345b-42db-b695-acca127ff205)

**Any feedback is welcome thx JoseVi.**

