### PR TITLE
Added XF86 media keys for Linux

### DIFF
--- a/pyautogui/_pyautogui_x11.py
+++ b/pyautogui/_pyautogui_x11.py
@@ -181,6 +181,8 @@ def _keyUp(key):
 # Taken from PyKeyboard's ctor function.
 _display = Display(os.environ['DISPLAY'])
 
+# Load XF86 Keysym definitions for special function keys
+Xlib.XK.load_keysym_group('xf86')
 
 """ Information for keyboardMapping derived from PyKeyboard's special_key_assignment() function.
 
@@ -314,6 +316,14 @@ keyboardMapping.update({
     '|': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('bar')),
     '}': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('braceright')),
     '~': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('asciitilde')),
+
+    # XF86 special function keys
+    'volumeup':         _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioRaiseVolume')),
+    'volumedown':       _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioLowerVolume')),
+    'volumemute':       _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioMute')),
+    'playpause':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioPlay')),
+    'nexttrack':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioNext')),
+    'prevtrack':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioPrev')),
 })
 
 # Trading memory for time" populate winKB so we don't have to call VkKeyScanA each time.

--- a/pyautogui/_pyautogui_x11.py
+++ b/pyautogui/_pyautogui_x11.py
@@ -181,9 +181,6 @@ def _keyUp(key):
 # Taken from PyKeyboard's ctor function.
 _display = Display(os.environ['DISPLAY'])
 
-# Load XF86 Keysym definitions for special function keys
-Xlib.XK.load_keysym_group('xf86')
-
 """ Information for keyboardMapping derived from PyKeyboard's special_key_assignment() function.
 
 The *KB dictionaries in pyautogui map a string that can be passed to keyDown(),
@@ -316,15 +313,24 @@ keyboardMapping.update({
     '|': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('bar')),
     '}': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('braceright')),
     '~': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('asciitilde')),
-
-    # XF86 special function keys
-    'volumeup':         _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioRaiseVolume')),
-    'volumedown':       _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioLowerVolume')),
-    'volumemute':       _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioMute')),
-    'playpause':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioPlay')),
-    'nexttrack':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioNext')),
-    'prevtrack':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioPrev')),
 })
+
+try:
+    # Load XF86 Keysym definitions for special function keys
+    Xlib.XK.load_keysym_group('xf86')
+
+    keyboardMapping.update({    
+        'volumeup':         _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioRaiseVolume')),
+        'volumedown':       _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioLowerVolume')),
+        'volumemute':       _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioMute')),
+        'playpause':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioPlay')),
+        'nexttrack':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioNext')),
+        'prevtrack':        _display.keysym_to_keycode(Xlib.XK.string_to_keysym('XF86_AudioPrev')),
+    })
+except Exception:
+    # Need minimum python-xlib v0.15rc1
+    # Don't don't raise exception and let x11 module work without XF86 keys
+    pass
 
 # Trading memory for time" populate winKB so we don't have to call VkKeyScanA each time.
 for c in """abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890""":


### PR DESCRIPTION
I noticed that media keys were missing for Linux (X11) for a project of mine. I've added the following keyboard_keys missing in Linux: volumeup, volumedown, volumemute, playpause, nexttrack, prevtrack

There are probably several other special keys that are missing for Linux, but for now media keys are a good starting point for adding XF86 compatibility.