### PR TITLE
keyDown strict mode

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -1539,7 +1539,7 @@ def isValidKey(key):
 
 
 @_genericPyAutoGUIChecks
-def keyDown(key, logScreenshot=None, _pause=True):
+def keyDown(key, logScreenshot=None, _pause=True, strict=False):
     """Performs a keyboard key press without the release. This will put that
     key in a held down state.
 
@@ -1548,8 +1548,9 @@ def keyDown(key, logScreenshot=None, _pause=True):
 
     Args:
       key (str): The key to be pressed down. The valid names are listed in
-      KEYBOARD_KEYS.
-
+        KEYBOARD_KEYS.
+      strict (bool, optional): If True and the key is not a valid value,
+        raise a ValueError.
     Returns:
       None
     """
@@ -1557,7 +1558,7 @@ def keyDown(key, logScreenshot=None, _pause=True):
         key = key.lower()
 
     _logScreenshot(logScreenshot, "keyDown", key, folder=".")
-    platformModule._keyDown(key)
+    platformModule._keyDown(key, strict)
 
 
 @_genericPyAutoGUIChecks

--- a/pyautogui/_pyautogui_osx.py
+++ b/pyautogui/_pyautogui_osx.py
@@ -216,8 +216,10 @@ special_key_translate_table = {
     'KEYTYPE_ILLUMINATION_TOGGLE': 23
 }
 
-def _keyDown(key):
+def _keyDown(key, strict=False):
     if key not in keyboardMapping or keyboardMapping[key] is None:
+        if strict:
+            raise ValueError("Key '%s' is not a valid key." % (key))
         return
 
     if key in special_key_translate_table:

--- a/pyautogui/_pyautogui_win.py
+++ b/pyautogui/_pyautogui_win.py
@@ -247,7 +247,7 @@ for c in range(32, 128):
     keyboardMapping[chr(c)] = ctypes.windll.user32.VkKeyScanA(ctypes.wintypes.WCHAR(chr(c)))
 
 
-def _keyDown(key):
+def _keyDown(key, strict=False):
     """Performs a keyboard key press without the release. This will put that
     key in a held down state.
 
@@ -256,12 +256,16 @@ def _keyDown(key):
 
     Args:
       key (str): The key to be pressed down. The valid names are listed in
-      pyautogui.KEY_NAMES.
+        pyautogui.KEY_NAMES.
+      strict (bool): If strict is True and the key is not a valid key, 
+        raise a ValueError.
 
     Returns:
       None
     """
     if key not in keyboardMapping or keyboardMapping[key] is None:
+        if strict:
+            raise ValueError('The key "%s" is not a valid key.' % (key))
         return
 
     needsShift = pyautogui.isShiftCharacter(key)

--- a/pyautogui/_pyautogui_x11.py
+++ b/pyautogui/_pyautogui_x11.py
@@ -118,7 +118,7 @@ def _mouseUp(x, y, button):
     _display.sync()
 
 
-def _keyDown(key):
+def _keyDown(key, strict=False):
     """Performs a keyboard key press without the release. This will put that
     key in a held down state.
 
@@ -128,11 +128,14 @@ def _keyDown(key):
     Args:
       key (str): The key to be pressed down. The valid names are listed in
       pyautogui.KEY_NAMES.
+      strict (bool, optional): If strict is True and the key is not recognized, will raise a ValueError.      
 
     Returns:
       None
     """
     if key not in keyboardMapping or keyboardMapping[key] is None:
+        if strict:
+            raise ValueError("Key "%s" is not a valid key." % key)
         return
 
     if type(key) == int:


### PR DESCRIPTION
this will make it easier to debug keyDown typo errors (which previously were totally ignored making it a silent no-op failure.)

For backwards-compatibility it's false-by-default (not sure that is actually a good idea: scripts hitting the failure are probably already broken! )