### PR TITLE
Added exception info to be inherited in pyautogui ImageNotFoundException

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -170,8 +170,8 @@ def raisePyAutoGUIImageNotFoundException(wrappedFunction):
     def wrapper(*args, **kwargs):
         try:
             return wrappedFunction(*args, **kwargs)
-        except pyscreeze.ImageNotFoundException:
-            raise ImageNotFoundException  # Raise PyAutoGUI's ImageNotFoundException.
+        except pyscreeze.ImageNotFoundException as ex:
+            raise ImageNotFoundException(ex)  # Raise PyAutoGUI's ImageNotFoundException.
 
     return wrapper
 


### PR DESCRIPTION
I tried using `pyautogui.locateCenterOnScreen` and handled exception to debug, but found that the exception message being passed from `pyscreeze.ImageNotFoundException` is lost in the decorator.

The code changes in this PR allows the info provided in the `pyscreeze` exception to bubble up the wrapper for better debugging in application side.

## Tests ran locally for validation

#### Test case 1: Using pyscreeze API directly
Code:
```python
try:
    return pyscreeze.locateCenterOnScreen(*args, minSearchTime=1, **kwargs), None
except pyscreeze.ImageNotFoundException as ex:
    logger.exception("Error in locating image on screen", extra={"error": ex})
```

Snippet of Log output:
```json
"exc_info": [
  "<class 'pyscreeze.ImageNotFoundException'>",
  "Could not locate the image (highest confidence = 0.912)",
  "File \"<path-to-repo>\\util\\autogui.py\", line 87, in locateCenterOnScreen\n    return pyscreeze.locateCenterOnScreen(*args, minSearchTime=1, **kwargs), None\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<path-to-repo>\\.venv\\Lib\\site-packages\\pyscreeze\\__init__.py\", line 447, in locateCenterOnScreen\n    coords = locateOnScreen(image, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<path-to-repo>\\.venv\\Lib\\site-packages\\pyscreeze\\__init__.py\", line 405, in locateOnScreen\n    retVal = locate(image, screenshotIm, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<path-to-repo>\\.venv\\Lib\\site-packages\\pyscreeze\\__init__.py\", line 383, in locate\n    points = tuple(locateAll(needleImage, haystackImage, **kwargs))\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<path-to-repo>\\.venv\\Lib\\site-packages\\pyscreeze\\__init__.py\", line 257, in _locateAll_opencv\n    raise ImageNotFoundException('Could not locate the image (highest confidence = %.3f)' % result.max())"
],
```
#### Test case 2: Using current pyautogui API
Code:
```python
try:
    return pyautogui.locateCenterOnScreen(*args, minSearchTime=1, **kwargs), None
except pyautogui.ImageNotFoundException as ex:
    logger.exception("Error in locating image on screen", extra={"error": ex})
```

Snippet of Log output:
```json
"exc_info": [
  "<class 'pyautogui.ImageNotFoundException'>",
  "",
  "File \"<path-to-repo>\\util\\autogui.py\", line 86, in locateCenterOnScreen\n    return pg.locateCenterOnScreen(*args, minSearchTime=1, **kwargs), None\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<path-to-repo>\\.venv\\Lib\\site-packages\\pyautogui\\__init__.py\", line 174, in wrapper\n    raise ImageNotFoundException  # Raise PyAutoGUI's ImageNotFoundException.\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
]
```

#### Test case 3: Using updated pyautogui API
Code:
```python
try:
    return pyscreeze.locateCenterOnScreen(*args, minSearchTime=1, **kwargs), None
except pyscreeze.ImageNotFoundException as ex:
    logger.exception("Error in locating image on screen", extra={"error": ex})
```

Snippet of Log output:
```json
"exc_info": [
  "<class 'pyautogui.ImageNotFoundException'>",
  "Could not locate the image (highest confidence = 0.641)",
  "File \"<path-to-repo>\\util\\autogui.py\", line 86, in locateCenterOnScreen\n    return pg.locateCenterOnScreen(*args, minSearchTime=1, **kwargs), None\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<path-to-repo>\\.venv\\Lib\\site-packages\\pyautogui\\__init__.py\", line 174, in wrapper\n    raise ImageNotFoundException(ex) # Raise PyAutoGUI's ImageNotFoundException.\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
],
```

