### PR TITLE
Add ability to convert png and other image files into a string that c…

### DIFF
--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -179,6 +179,8 @@ def raisePyAutoGUIImageNotFoundException(wrappedFunction):
 try:
     import pyscreeze
     from pyscreeze import center, pixel, pixelMatchesColor, screenshot
+    from PIL import Image    
+    import io, base64
 
     # Change the locate*() functions so that they raise PyAutoGUI's ImageNotFoundException instead.
     @raisePyAutoGUIImageNotFoundException
@@ -216,6 +218,33 @@ try:
         return pyscreeze.locateOnWindow(*args, **kwargs)
 
     locateOnWindow.__doc__ = pyscreeze.locateOnWindow.__doc__
+    
+    def ImageToBase64(image, format='PNG'):
+        """Converts an image to a base64 string.
+
+        Args:
+            image (Image): The image to convert.
+            format (str, optional): The format of the image. Defaults to 'PNG'.
+
+        Returns:
+            str: The base64 string of the image.
+        """
+        imgByteArr = io.BytesIO()
+        image.save(imgByteArr, format)
+        imgByteArr = imgByteArr.getvalue()
+        return base64.b64encode(imgByteArr).decode('utf-8')    
+    
+    def Base64ToImage(base64_string):
+        """Converts a base64 string to an Image.
+        
+        Args:
+            base64_string (str): The base64 string to convert.
+            
+        Returns:
+            Image: The image.
+        """
+        imgdata = base64.b64decode(base64_string)
+        return Image.open(io.BytesIO(imgdata))
 
 
 except ImportError:


### PR DESCRIPTION
add ability to convert png and other image files into a string that can be copy/pasted directly in the source code, so that they don’t have to be shared separately with people’s pyautogui scripts. (ImageToBase64 e Base64ToImage)

usage:
```python

import pyautogui
im = pyautogui.screenshot(region=(0,0, 300, 400))
b64img = ImageToBase64(im)
print(b64img)
...

im2 = Base64ToImage(b64img)
region = pyautogui.locateOnScreen(im2)
```