### PR TITLE
Fix `SyntaxWarning: invalid escape sequence '\e'`

### DIFF
--- a/pyautogui/_pyautogui_x11.py
+++ b/pyautogui/_pyautogui_x11.py
@@ -281,7 +281,6 @@ keyboardMapping.update({
     '\t': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Tab')),
     '\n': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Return')),  # for some reason this needs to be cr, not lf
     '\r': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Return')),
-    '\e': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('Escape')),
     '!': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('exclam')),
     '#': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('numbersign')),
     '%': _display.keysym_to_keycode(Xlib.XK.string_to_keysym('percent')),


### PR DESCRIPTION
Closes #423